### PR TITLE
Upgrade BlocjerkTokenV6 on Arbitrum

### DIFF
--- a/.openzeppelin/unknown-11155111.json
+++ b/.openzeppelin/unknown-11155111.json
@@ -2441,6 +2441,368 @@
           }
         }
       }
+    },
+    "4b0256ff1c1b6e283ecfe7f7a794d3a3c64b2f5926bea67c299c84a63180eff1": {
+      "address": "0x9305c71b0BeE7C3f7a9DA0A9F544aafecaA33Ff4",
+      "txHash": "0xc2e9f8dbe495e4e1173f2dde9fc1e8b5f9abddd8798a50812ccf8a59255543a5",
+      "layout": {
+        "solcVersion": "0.8.3",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:39"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:41"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:43"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:45"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:364"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20PausableUpgradeable",
+            "src": "contracts/oz/ERC20PausableUpgradeable.sol:46"
+          },
+          {
+            "label": "_accountBalanceSnapshots",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_mapping(t_address,t_struct(Snapshots)4901_storage)",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:55"
+          },
+          {
+            "label": "_totalSupplySnapshots",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_struct(Snapshots)4901_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:56"
+          },
+          {
+            "label": "_currentSnapshotId",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_struct(Counter)993_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:59"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_array(t_uint256)46_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:211"
+          },
+          {
+            "label": "authorizedToSnapshot",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:40"
+          },
+          {
+            "label": "buyTaxRate",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:45"
+          },
+          {
+            "label": "sellTaxRate",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:46"
+          },
+          {
+            "label": "poolsToTax",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:52"
+          },
+          {
+            "label": "taxTo",
+            "offset": 0,
+            "slot": "305",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:54"
+          },
+          {
+            "label": "accumulatedTax",
+            "offset": 0,
+            "slot": "306",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:57"
+          },
+          {
+            "label": "version",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:59"
+          },
+          {
+            "label": "uniswapV2Router",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_contract(IUniswapV2Router02)2835",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:13"
+          },
+          {
+            "label": "uniswapV2Pair",
+            "offset": 0,
+            "slot": "309",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:15"
+          },
+          {
+            "label": "routerAddr",
+            "offset": 0,
+            "slot": "310",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:17"
+          },
+          {
+            "label": "minTaxForSell",
+            "offset": 0,
+            "slot": "311",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:22"
+          },
+          {
+            "label": "USDT",
+            "offset": 0,
+            "slot": "312",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:25"
+          },
+          {
+            "label": "inTriggerProcess",
+            "offset": 20,
+            "slot": "312",
+            "type": "t_bool",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:27"
+          },
+          {
+            "label": "uniswapV3Router",
+            "offset": 0,
+            "slot": "313",
+            "type": "t_contract(IUniswapRouter02)4792",
+            "contract": "UniswapV3",
+            "src": "contracts/core/UniswapV3.sol:14"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)46_storage": {
+            "label": "uint256[46]",
+            "numberOfBytes": "1472"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IUniswapRouter02)4792": {
+            "label": "contract IUniswapRouter02",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IUniswapV2Router02)2835": {
+            "label": "contract IUniswapV2Router02",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Snapshots)4901_storage)": {
+            "label": "mapping(address => struct ERC20SnapshotUpgradeable.Snapshots)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Counter)993_storage": {
+            "label": "struct CountersUpgradeable.Counter",
+            "members": [
+              {
+                "label": "_value",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Snapshots)4901_storage": {
+            "label": "struct ERC20SnapshotUpgradeable.Snapshots",
+            "members": [
+              {
+                "label": "ids",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "values",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-11155111.json
+++ b/.openzeppelin/unknown-11155111.json
@@ -993,6 +993,1092 @@
           }
         }
       }
+    },
+    "0bbe7c17c97f1a68d8dc8481e2f2fa2a7589491f2d7cf1bcd1ee7990af1711d2": {
+      "address": "0x84318a370Dc9a488eC9C74ae207F427D05334Ff1",
+      "txHash": "0xa4a1844db8fcd551795ef9540a934b31de31c7fb5ddc1613311854b8f915099b",
+      "layout": {
+        "solcVersion": "0.8.3",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:39"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:41"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:43"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:45"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:364"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20PausableUpgradeable",
+            "src": "contracts/oz/ERC20PausableUpgradeable.sol:46"
+          },
+          {
+            "label": "_accountBalanceSnapshots",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_mapping(t_address,t_struct(Snapshots)4609_storage)",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:55"
+          },
+          {
+            "label": "_totalSupplySnapshots",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_struct(Snapshots)4609_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:56"
+          },
+          {
+            "label": "_currentSnapshotId",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_struct(Counter)993_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:59"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_array(t_uint256)46_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:211"
+          },
+          {
+            "label": "authorizedToSnapshot",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:40"
+          },
+          {
+            "label": "buyTaxRate",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:45"
+          },
+          {
+            "label": "sellTaxRate",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:46"
+          },
+          {
+            "label": "poolsToTax",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:52"
+          },
+          {
+            "label": "taxTo",
+            "offset": 0,
+            "slot": "305",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:54"
+          },
+          {
+            "label": "accumulatedTax",
+            "offset": 0,
+            "slot": "306",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:57"
+          },
+          {
+            "label": "version",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:59"
+          },
+          {
+            "label": "uniswapV2Router",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_contract(IUniswapV2Router02)2835",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:13"
+          },
+          {
+            "label": "uniswapV2Pair",
+            "offset": 0,
+            "slot": "309",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:15"
+          },
+          {
+            "label": "routerAddr",
+            "offset": 0,
+            "slot": "310",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:17"
+          },
+          {
+            "label": "minTaxForSell",
+            "offset": 0,
+            "slot": "311",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:22"
+          },
+          {
+            "label": "USDT",
+            "offset": 0,
+            "slot": "312",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:25"
+          },
+          {
+            "label": "inTriggerProcess",
+            "offset": 20,
+            "slot": "312",
+            "type": "t_bool",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:27"
+          },
+          {
+            "label": "uniswapV3Router",
+            "offset": 0,
+            "slot": "313",
+            "type": "t_contract(ISwapRouter)2949",
+            "contract": "UniswapV3",
+            "src": "contracts/core/UniswapV3.sol:9"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)46_storage": {
+            "label": "uint256[46]",
+            "numberOfBytes": "1472"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(ISwapRouter)2949": {
+            "label": "contract ISwapRouter",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IUniswapV2Router02)2835": {
+            "label": "contract IUniswapV2Router02",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Snapshots)4609_storage)": {
+            "label": "mapping(address => struct ERC20SnapshotUpgradeable.Snapshots)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Counter)993_storage": {
+            "label": "struct CountersUpgradeable.Counter",
+            "members": [
+              {
+                "label": "_value",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Snapshots)4609_storage": {
+            "label": "struct ERC20SnapshotUpgradeable.Snapshots",
+            "members": [
+              {
+                "label": "ids",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "values",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "5d312797ed9719b4c7d7b5f8276e53761436511a1d44c5411f9969b3e080e9b0": {
+      "address": "0xf43DA25b0F0Fb3857950D104dCea41240436dF96",
+      "txHash": "0x42b59786eca13942fa33183b071dccd447b3e5ef72604f85970e5bd3f158e1a9",
+      "layout": {
+        "solcVersion": "0.8.3",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:39"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:41"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:43"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:45"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:364"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20PausableUpgradeable",
+            "src": "contracts/oz/ERC20PausableUpgradeable.sol:46"
+          },
+          {
+            "label": "_accountBalanceSnapshots",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_mapping(t_address,t_struct(Snapshots)4609_storage)",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:55"
+          },
+          {
+            "label": "_totalSupplySnapshots",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_struct(Snapshots)4609_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:56"
+          },
+          {
+            "label": "_currentSnapshotId",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_struct(Counter)993_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:59"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_array(t_uint256)46_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:211"
+          },
+          {
+            "label": "authorizedToSnapshot",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:40"
+          },
+          {
+            "label": "buyTaxRate",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:45"
+          },
+          {
+            "label": "sellTaxRate",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:46"
+          },
+          {
+            "label": "poolsToTax",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:52"
+          },
+          {
+            "label": "taxTo",
+            "offset": 0,
+            "slot": "305",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:54"
+          },
+          {
+            "label": "accumulatedTax",
+            "offset": 0,
+            "slot": "306",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:57"
+          },
+          {
+            "label": "version",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:59"
+          },
+          {
+            "label": "uniswapV2Router",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_contract(IUniswapV2Router02)2835",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:13"
+          },
+          {
+            "label": "uniswapV2Pair",
+            "offset": 0,
+            "slot": "309",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:15"
+          },
+          {
+            "label": "routerAddr",
+            "offset": 0,
+            "slot": "310",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:17"
+          },
+          {
+            "label": "minTaxForSell",
+            "offset": 0,
+            "slot": "311",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:22"
+          },
+          {
+            "label": "USDT",
+            "offset": 0,
+            "slot": "312",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:25"
+          },
+          {
+            "label": "inTriggerProcess",
+            "offset": 20,
+            "slot": "312",
+            "type": "t_bool",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:27"
+          },
+          {
+            "label": "uniswapV3Router",
+            "offset": 0,
+            "slot": "313",
+            "type": "t_contract(ISwapRouter)2949",
+            "contract": "UniswapV3",
+            "src": "contracts/core/UniswapV3.sol:9"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)46_storage": {
+            "label": "uint256[46]",
+            "numberOfBytes": "1472"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(ISwapRouter)2949": {
+            "label": "contract ISwapRouter",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IUniswapV2Router02)2835": {
+            "label": "contract IUniswapV2Router02",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Snapshots)4609_storage)": {
+            "label": "mapping(address => struct ERC20SnapshotUpgradeable.Snapshots)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Counter)993_storage": {
+            "label": "struct CountersUpgradeable.Counter",
+            "members": [
+              {
+                "label": "_value",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Snapshots)4609_storage": {
+            "label": "struct ERC20SnapshotUpgradeable.Snapshots",
+            "members": [
+              {
+                "label": "ids",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "values",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "cda79acce66eea16d94cbafad98d7d6b770c41bfc7c833a0be24f0a0e1fe89f2": {
+      "address": "0x7F286Bcbf4d83E62077760d798089576c30B58D5",
+      "txHash": "0x007321d82f3a3ba02363b20e404ce033a431fdf5d451cd0715226a11dda02527",
+      "layout": {
+        "solcVersion": "0.8.3",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:39"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:41"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:43"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:45"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:364"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20PausableUpgradeable",
+            "src": "contracts/oz/ERC20PausableUpgradeable.sol:46"
+          },
+          {
+            "label": "_accountBalanceSnapshots",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_mapping(t_address,t_struct(Snapshots)4609_storage)",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:55"
+          },
+          {
+            "label": "_totalSupplySnapshots",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_struct(Snapshots)4609_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:56"
+          },
+          {
+            "label": "_currentSnapshotId",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_struct(Counter)993_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:59"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_array(t_uint256)46_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:211"
+          },
+          {
+            "label": "authorizedToSnapshot",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:40"
+          },
+          {
+            "label": "buyTaxRate",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:45"
+          },
+          {
+            "label": "sellTaxRate",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:46"
+          },
+          {
+            "label": "poolsToTax",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:52"
+          },
+          {
+            "label": "taxTo",
+            "offset": 0,
+            "slot": "305",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:54"
+          },
+          {
+            "label": "accumulatedTax",
+            "offset": 0,
+            "slot": "306",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:57"
+          },
+          {
+            "label": "version",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:59"
+          },
+          {
+            "label": "uniswapV2Router",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_contract(IUniswapV2Router02)2835",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:13"
+          },
+          {
+            "label": "uniswapV2Pair",
+            "offset": 0,
+            "slot": "309",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:15"
+          },
+          {
+            "label": "routerAddr",
+            "offset": 0,
+            "slot": "310",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:17"
+          },
+          {
+            "label": "minTaxForSell",
+            "offset": 0,
+            "slot": "311",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:22"
+          },
+          {
+            "label": "USDT",
+            "offset": 0,
+            "slot": "312",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:25"
+          },
+          {
+            "label": "inTriggerProcess",
+            "offset": 20,
+            "slot": "312",
+            "type": "t_bool",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:27"
+          },
+          {
+            "label": "uniswapV3Router",
+            "offset": 0,
+            "slot": "313",
+            "type": "t_contract(ISwapRouter)2949",
+            "contract": "UniswapV3",
+            "src": "contracts/core/UniswapV3.sol:9"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)46_storage": {
+            "label": "uint256[46]",
+            "numberOfBytes": "1472"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(ISwapRouter)2949": {
+            "label": "contract ISwapRouter",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IUniswapV2Router02)2835": {
+            "label": "contract IUniswapV2Router02",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Snapshots)4609_storage)": {
+            "label": "mapping(address => struct ERC20SnapshotUpgradeable.Snapshots)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Counter)993_storage": {
+            "label": "struct CountersUpgradeable.Counter",
+            "members": [
+              {
+                "label": "_value",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Snapshots)4609_storage": {
+            "label": "struct ERC20SnapshotUpgradeable.Snapshots",
+            "members": [
+              {
+                "label": "ids",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "values",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-11155111.json
+++ b/.openzeppelin/unknown-11155111.json
@@ -2803,6 +2803,368 @@
           }
         }
       }
+    },
+    "b59a13c59764dd8cd4310aa158d9ebab0bc7d23585862f55f0d4320f699c2eec": {
+      "address": "0xd43eEEe3aE1BEC1Eb847be0bf994F7A22f740737",
+      "txHash": "0x57b36e1860deba384b1c1e0d5ba314e856342a1ae503611e2f78e9ff9bc37675",
+      "layout": {
+        "solcVersion": "0.8.3",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:39"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:41"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:43"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:45"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:364"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20PausableUpgradeable",
+            "src": "contracts/oz/ERC20PausableUpgradeable.sol:46"
+          },
+          {
+            "label": "_accountBalanceSnapshots",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_mapping(t_address,t_struct(Snapshots)4900_storage)",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:55"
+          },
+          {
+            "label": "_totalSupplySnapshots",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_struct(Snapshots)4900_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:56"
+          },
+          {
+            "label": "_currentSnapshotId",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_struct(Counter)993_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:59"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_array(t_uint256)46_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:211"
+          },
+          {
+            "label": "authorizedToSnapshot",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:40"
+          },
+          {
+            "label": "buyTaxRate",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:45"
+          },
+          {
+            "label": "sellTaxRate",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:46"
+          },
+          {
+            "label": "poolsToTax",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:52"
+          },
+          {
+            "label": "taxTo",
+            "offset": 0,
+            "slot": "305",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:54"
+          },
+          {
+            "label": "accumulatedTax",
+            "offset": 0,
+            "slot": "306",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:57"
+          },
+          {
+            "label": "version",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:59"
+          },
+          {
+            "label": "uniswapV2Router",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_contract(IUniswapV2Router02)2835",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:13"
+          },
+          {
+            "label": "uniswapV2Pair",
+            "offset": 0,
+            "slot": "309",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:15"
+          },
+          {
+            "label": "routerAddr",
+            "offset": 0,
+            "slot": "310",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:17"
+          },
+          {
+            "label": "minTaxForSell",
+            "offset": 0,
+            "slot": "311",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:22"
+          },
+          {
+            "label": "USDT",
+            "offset": 0,
+            "slot": "312",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:25"
+          },
+          {
+            "label": "inTriggerProcess",
+            "offset": 20,
+            "slot": "312",
+            "type": "t_bool",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:27"
+          },
+          {
+            "label": "uniswapV3Router",
+            "offset": 0,
+            "slot": "313",
+            "type": "t_contract(IUniswapRouter02)4791",
+            "contract": "UniswapV3",
+            "src": "contracts/core/UniswapV3.sol:15"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)46_storage": {
+            "label": "uint256[46]",
+            "numberOfBytes": "1472"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IUniswapRouter02)4791": {
+            "label": "contract IUniswapRouter02",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IUniswapV2Router02)2835": {
+            "label": "contract IUniswapV2Router02",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Snapshots)4900_storage)": {
+            "label": "mapping(address => struct ERC20SnapshotUpgradeable.Snapshots)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Counter)993_storage": {
+            "label": "struct CountersUpgradeable.Counter",
+            "members": [
+              {
+                "label": "_value",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Snapshots)4900_storage": {
+            "label": "struct ERC20SnapshotUpgradeable.Snapshots",
+            "members": [
+              {
+                "label": "ids",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "values",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-11155111.json
+++ b/.openzeppelin/unknown-11155111.json
@@ -2079,6 +2079,368 @@
           }
         }
       }
+    },
+    "2fd5543b38dd46b13af9414f051952651ff65d2faa86dc81f126047d196752d3": {
+      "address": "0xfDc1dC05C6D60d7dAD72146330E1E38459839688",
+      "txHash": "0xf2ef1f0a155e8d2e55522fc174581173a89c7ae7850ec315df5bb957d21fdbf3",
+      "layout": {
+        "solcVersion": "0.8.3",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:39"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:41"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:43"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:45"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:364"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20PausableUpgradeable",
+            "src": "contracts/oz/ERC20PausableUpgradeable.sol:46"
+          },
+          {
+            "label": "_accountBalanceSnapshots",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_mapping(t_address,t_struct(Snapshots)4899_storage)",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:55"
+          },
+          {
+            "label": "_totalSupplySnapshots",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_struct(Snapshots)4899_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:56"
+          },
+          {
+            "label": "_currentSnapshotId",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_struct(Counter)993_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:59"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_array(t_uint256)46_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:211"
+          },
+          {
+            "label": "authorizedToSnapshot",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:40"
+          },
+          {
+            "label": "buyTaxRate",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:45"
+          },
+          {
+            "label": "sellTaxRate",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:46"
+          },
+          {
+            "label": "poolsToTax",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:52"
+          },
+          {
+            "label": "taxTo",
+            "offset": 0,
+            "slot": "305",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:54"
+          },
+          {
+            "label": "accumulatedTax",
+            "offset": 0,
+            "slot": "306",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:57"
+          },
+          {
+            "label": "version",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:59"
+          },
+          {
+            "label": "uniswapV2Router",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_contract(IUniswapV2Router02)2835",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:13"
+          },
+          {
+            "label": "uniswapV2Pair",
+            "offset": 0,
+            "slot": "309",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:15"
+          },
+          {
+            "label": "routerAddr",
+            "offset": 0,
+            "slot": "310",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:17"
+          },
+          {
+            "label": "minTaxForSell",
+            "offset": 0,
+            "slot": "311",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:22"
+          },
+          {
+            "label": "USDT",
+            "offset": 0,
+            "slot": "312",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:25"
+          },
+          {
+            "label": "inTriggerProcess",
+            "offset": 20,
+            "slot": "312",
+            "type": "t_bool",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:27"
+          },
+          {
+            "label": "uniswapV3Router",
+            "offset": 0,
+            "slot": "313",
+            "type": "t_contract(IUniswapRouter02)4790",
+            "contract": "UniswapV3",
+            "src": "contracts/core/UniswapV3.sol:14"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)46_storage": {
+            "label": "uint256[46]",
+            "numberOfBytes": "1472"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IUniswapRouter02)4790": {
+            "label": "contract IUniswapRouter02",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IUniswapV2Router02)2835": {
+            "label": "contract IUniswapV2Router02",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Snapshots)4899_storage)": {
+            "label": "mapping(address => struct ERC20SnapshotUpgradeable.Snapshots)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Counter)993_storage": {
+            "label": "struct CountersUpgradeable.Counter",
+            "members": [
+              {
+                "label": "_value",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Snapshots)4899_storage": {
+            "label": "struct ERC20SnapshotUpgradeable.Snapshots",
+            "members": [
+              {
+                "label": "ids",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "values",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-11155111.json
+++ b/.openzeppelin/unknown-11155111.json
@@ -3165,6 +3165,368 @@
           }
         }
       }
+    },
+    "d74d8eb4134c111051c4d860bbc2329449771a0e07d5bd229f32e303237ed2f4": {
+      "address": "0x51240Ff180611615ebD0EA6D207B34f71116D408",
+      "txHash": "0x626fac7077d2c2337c3109c2a7e00ba37d681f83e2fe4a40dbc894eba2c54057",
+      "layout": {
+        "solcVersion": "0.8.3",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:39"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:41"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:43"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:45"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:364"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20PausableUpgradeable",
+            "src": "contracts/oz/ERC20PausableUpgradeable.sol:46"
+          },
+          {
+            "label": "_accountBalanceSnapshots",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_mapping(t_address,t_struct(Snapshots)4854_storage)",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:55"
+          },
+          {
+            "label": "_totalSupplySnapshots",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_struct(Snapshots)4854_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:56"
+          },
+          {
+            "label": "_currentSnapshotId",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_struct(Counter)993_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:59"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_array(t_uint256)46_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:211"
+          },
+          {
+            "label": "authorizedToSnapshot",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:40"
+          },
+          {
+            "label": "buyTaxRate",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:45"
+          },
+          {
+            "label": "sellTaxRate",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:46"
+          },
+          {
+            "label": "poolsToTax",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:52"
+          },
+          {
+            "label": "taxTo",
+            "offset": 0,
+            "slot": "305",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:54"
+          },
+          {
+            "label": "accumulatedTax",
+            "offset": 0,
+            "slot": "306",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:57"
+          },
+          {
+            "label": "version",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:59"
+          },
+          {
+            "label": "uniswapV2Router",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_contract(IUniswapV2Router02)2835",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:13"
+          },
+          {
+            "label": "uniswapV2Pair",
+            "offset": 0,
+            "slot": "309",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:15"
+          },
+          {
+            "label": "routerAddr",
+            "offset": 0,
+            "slot": "310",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:17"
+          },
+          {
+            "label": "minTaxForSell",
+            "offset": 0,
+            "slot": "311",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:22"
+          },
+          {
+            "label": "USDT",
+            "offset": 0,
+            "slot": "312",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:25"
+          },
+          {
+            "label": "inTriggerProcess",
+            "offset": 20,
+            "slot": "312",
+            "type": "t_bool",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:27"
+          },
+          {
+            "label": "uniswapV3Router",
+            "offset": 0,
+            "slot": "313",
+            "type": "t_contract(IUniswapRouter02)4745",
+            "contract": "UniswapV3",
+            "src": "contracts/core/UniswapV3.sol:15"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)46_storage": {
+            "label": "uint256[46]",
+            "numberOfBytes": "1472"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IUniswapRouter02)4745": {
+            "label": "contract IUniswapRouter02",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IUniswapV2Router02)2835": {
+            "label": "contract IUniswapV2Router02",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Snapshots)4854_storage)": {
+            "label": "mapping(address => struct ERC20SnapshotUpgradeable.Snapshots)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Counter)993_storage": {
+            "label": "struct CountersUpgradeable.Counter",
+            "members": [
+              {
+                "label": "_value",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Snapshots)4854_storage": {
+            "label": "struct ERC20SnapshotUpgradeable.Snapshots",
+            "members": [
+              {
+                "label": "ids",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "values",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-11155111.json
+++ b/.openzeppelin/unknown-11155111.json
@@ -3527,6 +3527,368 @@
           }
         }
       }
+    },
+    "e7e34418ced41e296a71c2e9b322bcebce8886705747ffd4ebf60effb510299f": {
+      "address": "0x5f635C2F91521E07f93E672C6Dd01215F0a17984",
+      "txHash": "0x8abf8d6e71675ee8370c0917d48a6f99a1be636070245f7db632a40114f4ff4a",
+      "layout": {
+        "solcVersion": "0.8.3",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:39"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:41"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:43"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:45"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:364"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20PausableUpgradeable",
+            "src": "contracts/oz/ERC20PausableUpgradeable.sol:46"
+          },
+          {
+            "label": "_accountBalanceSnapshots",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_mapping(t_address,t_struct(Snapshots)4793_storage)",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:55"
+          },
+          {
+            "label": "_totalSupplySnapshots",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_struct(Snapshots)4793_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:56"
+          },
+          {
+            "label": "_currentSnapshotId",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_struct(Counter)993_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:59"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_array(t_uint256)46_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:211"
+          },
+          {
+            "label": "authorizedToSnapshot",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:40"
+          },
+          {
+            "label": "buyTaxRate",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:45"
+          },
+          {
+            "label": "sellTaxRate",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:46"
+          },
+          {
+            "label": "poolsToTax",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:52"
+          },
+          {
+            "label": "taxTo",
+            "offset": 0,
+            "slot": "305",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:54"
+          },
+          {
+            "label": "accumulatedTax",
+            "offset": 0,
+            "slot": "306",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:57"
+          },
+          {
+            "label": "version",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:59"
+          },
+          {
+            "label": "uniswapV2Router",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_contract(IUniswapV2Router02)2835",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:13"
+          },
+          {
+            "label": "uniswapV2Pair",
+            "offset": 0,
+            "slot": "309",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:15"
+          },
+          {
+            "label": "routerAddr",
+            "offset": 0,
+            "slot": "310",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:17"
+          },
+          {
+            "label": "minTaxForSell",
+            "offset": 0,
+            "slot": "311",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:22"
+          },
+          {
+            "label": "USDT",
+            "offset": 0,
+            "slot": "312",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:25"
+          },
+          {
+            "label": "inTriggerProcess",
+            "offset": 20,
+            "slot": "312",
+            "type": "t_bool",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:27"
+          },
+          {
+            "label": "uniswapV3Router",
+            "offset": 0,
+            "slot": "313",
+            "type": "t_contract(IUniswapRouter02)4684",
+            "contract": "UniswapV3",
+            "src": "contracts/core/UniswapV3.sol:15"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)46_storage": {
+            "label": "uint256[46]",
+            "numberOfBytes": "1472"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IUniswapRouter02)4684": {
+            "label": "contract IUniswapRouter02",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IUniswapV2Router02)2835": {
+            "label": "contract IUniswapV2Router02",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Snapshots)4793_storage)": {
+            "label": "mapping(address => struct ERC20SnapshotUpgradeable.Snapshots)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Counter)993_storage": {
+            "label": "struct CountersUpgradeable.Counter",
+            "members": [
+              {
+                "label": "_value",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Snapshots)4793_storage": {
+            "label": "struct ERC20SnapshotUpgradeable.Snapshots",
+            "members": [
+              {
+                "label": "ids",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "values",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-42161.json
+++ b/.openzeppelin/unknown-42161.json
@@ -6,76 +6,6 @@
   },
   "proxies": [
     {
-      "address": "0xE473C3e0B277255Baf321A75fcf6Ce2C279cD278",
-      "txHash": "0x6d0aac1344291f6b942f58807f267602018a1fdf5015d27bcef625c40c5601b2",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x99BB69Ee1BbFC7706C3ebb79b21C5B698fe58EC0",
-      "txHash": "0xa19be79467a33bf926e3f26dc82e0559b759bbbc9df9c852256965bac9e4ea50",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x4FAF1D85cf2f8aad2c53621cBD9752931fA8C7d3",
-      "txHash": "0xc997784589b83462152a7e89339027f4629e941c9e851771b78c5b4e183f7ab6",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xaA3e72d4EeBA32228b53bd921d80464c9b94031F",
-      "txHash": "0xf7f787e9db4a8f9acf54c9e45e38bd33ef879fe6664c9139fa422616726e2cde",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x6051e59eb50BB568415B6C476Fbd394EEF83834D",
-      "txHash": "0x5ef1f2f3bcd85f0863ed3f1eca15f504a52f7372a4a300fe355a9045c517fd37",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x4F5cB2AE10b511F1204C71Bb60A6489cEc708164",
-      "txHash": "0xf561fb73e1e94117cf19c97e083a947fee2c7b9d58b7141ca95a0f9f96d5961b",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x3c8916a61076D32edb35B07541b594a7D4C761da",
-      "txHash": "0x81e6882b04bf6844466b56fbe7ca849b6c71bbc6c8877ca27f65efef41c94771",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xa0CA81546A795DD8b8968baC159d027D33Ac897f",
-      "txHash": "0x2378748cd2de14c4110fdea632a105ae2011a960484e143c93b92c16a68d1b15",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x7F25290Fce7731341C3C2ae1bC5aC54892F041e7",
-      "txHash": "0xc675facdc667e61b67640ce5ba5988957b550b2272c711b65454dafcc1070407",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xA3454311D23F249E3BC615cB46D19f051eF6fe49",
-      "txHash": "0x35122d3558e00a4aa64433afb7bb9423703eb264f16a855b69a5cb17f1b03b47",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x2b172f86Ea6EE77D33829B62517679cF3A18fde4",
-      "txHash": "0xc0c039a3496da5678c7eda64b8f3c2a2c38cd6d362670d8e821a6aaf20df0d18",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xcbdD19f802D0276b71022870cF396e07071B62fF",
-      "txHash": "0x15b8caff30851105fe793cc298223d19bb1b279dec1d674443d0c17fdf5d8b90",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x9123e113BD21C50f436Ab41d25f16674b9Fea64D",
-      "txHash": "0xb6399ecf5e4fe399da3c153c8ce73e80061d7c92adc3480b44e5855449c617cf",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x496bA70C031209590f10944E6AAfa5B9cC7B7a83",
-      "txHash": "0xceb06d63b49b861bbe33476ecd9f0b74fa29a5b0a233c6c4fc654f7d64263567",
-      "kind": "transparent"
-    },
-    {
       "address": "0x9cAAe40DCF950aFEA443119e51E821D6FE2437ca",
       "txHash": "0xe87d6156c6aea23b387ba334bff44abaf8db98a9440094fee6ad8ed6a9683a34",
       "kind": "transparent"
@@ -205,7 +135,7 @@
             "label": "_accountBalanceSnapshots",
             "offset": 0,
             "slot": "251",
-            "type": "t_mapping(t_address,t_struct(Snapshots)2841_storage)",
+            "type": "t_mapping(t_address,t_struct(Snapshots)5033_storage)",
             "contract": "ERC20SnapshotUpgradeable",
             "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:55"
           },
@@ -213,7 +143,7 @@
             "label": "_totalSupplySnapshots",
             "offset": 0,
             "slot": "252",
-            "type": "t_struct(Snapshots)2841_storage",
+            "type": "t_struct(Snapshots)5033_storage",
             "contract": "ERC20SnapshotUpgradeable",
             "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:56"
           },
@@ -311,7 +241,7 @@
             "label": "mapping(address => mapping(address => uint256))",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_address,t_struct(Snapshots)2841_storage)": {
+          "t_mapping(t_address,t_struct(Snapshots)5033_storage)": {
             "label": "mapping(address => struct ERC20SnapshotUpgradeable.Snapshots)",
             "numberOfBytes": "32"
           },
@@ -335,7 +265,707 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(Snapshots)2841_storage": {
+          "t_struct(Snapshots)5033_storage": {
+            "label": "struct ERC20SnapshotUpgradeable.Snapshots",
+            "members": [
+              {
+                "label": "ids",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "values",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "dbbd64089f43e26efa30dbc050ecf7ac5be6f31740ed5309851870f956f33453": {
+      "address": "0x11e47C81b8090a2F119B9b304FA6d3FF445e4028",
+      "txHash": "0x4be0be57b2bcd50f9ef80b4bd146ac64fe3ef9b6b6900322e8eb05ad4d9dfa7d",
+      "layout": {
+        "solcVersion": "0.8.3",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:39"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:41"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:43"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:45"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:364"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20PausableUpgradeable",
+            "src": "contracts/oz/ERC20PausableUpgradeable.sol:46"
+          },
+          {
+            "label": "_accountBalanceSnapshots",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_mapping(t_address,t_struct(Snapshots)4275_storage)",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:55"
+          },
+          {
+            "label": "_totalSupplySnapshots",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_struct(Snapshots)4275_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:56"
+          },
+          {
+            "label": "_currentSnapshotId",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_struct(Counter)993_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:59"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_array(t_uint256)46_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:211"
+          },
+          {
+            "label": "authorizedToSnapshot",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:40"
+          },
+          {
+            "label": "buyTaxRate",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:45"
+          },
+          {
+            "label": "sellTaxRate",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:46"
+          },
+          {
+            "label": "poolsToTax",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:52"
+          },
+          {
+            "label": "taxTo",
+            "offset": 0,
+            "slot": "305",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:54"
+          },
+          {
+            "label": "accumulatedTax",
+            "offset": 0,
+            "slot": "306",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:57"
+          },
+          {
+            "label": "version",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:59"
+          },
+          {
+            "label": "uniswapV2Router",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_contract(IUniswapV2Router02)2835",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:12"
+          },
+          {
+            "label": "uniswapV2Pair",
+            "offset": 0,
+            "slot": "309",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:14"
+          },
+          {
+            "label": "routerAddr",
+            "offset": 0,
+            "slot": "310",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:16"
+          },
+          {
+            "label": "minTaxForSell",
+            "offset": 0,
+            "slot": "311",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:22"
+          },
+          {
+            "label": "USDT",
+            "offset": 0,
+            "slot": "312",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:24"
+          },
+          {
+            "label": "inTriggerProcess",
+            "offset": 20,
+            "slot": "312",
+            "type": "t_bool",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:26"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)46_storage": {
+            "label": "uint256[46]",
+            "numberOfBytes": "1472"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IUniswapV2Router02)2835": {
+            "label": "contract IUniswapV2Router02",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Snapshots)4275_storage)": {
+            "label": "mapping(address => struct ERC20SnapshotUpgradeable.Snapshots)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Counter)993_storage": {
+            "label": "struct CountersUpgradeable.Counter",
+            "members": [
+              {
+                "label": "_value",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Snapshots)4275_storage": {
+            "label": "struct ERC20SnapshotUpgradeable.Snapshots",
+            "members": [
+              {
+                "label": "ids",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "values",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "56a8d3372962dc139d15b10c0be27ef7c7958065120c08a53c89fd98e7b1e5cf": {
+      "address": "0x68C978CB0c3BbfB8bD793c185B9D7cff026Ec9fB",
+      "txHash": "0xc24a433c6ffa44880a4c02cb736d8ace495d708adbd6314de2d8f8c5aed58d6e",
+      "layout": {
+        "solcVersion": "0.8.3",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:39"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:41"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:43"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:45"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:364"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20PausableUpgradeable",
+            "src": "contracts/oz/ERC20PausableUpgradeable.sol:46"
+          },
+          {
+            "label": "_accountBalanceSnapshots",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_mapping(t_address,t_struct(Snapshots)4285_storage)",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:55"
+          },
+          {
+            "label": "_totalSupplySnapshots",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_struct(Snapshots)4285_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:56"
+          },
+          {
+            "label": "_currentSnapshotId",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_struct(Counter)993_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:59"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_array(t_uint256)46_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:211"
+          },
+          {
+            "label": "authorizedToSnapshot",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:40"
+          },
+          {
+            "label": "buyTaxRate",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:45"
+          },
+          {
+            "label": "sellTaxRate",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:46"
+          },
+          {
+            "label": "poolsToTax",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:52"
+          },
+          {
+            "label": "taxTo",
+            "offset": 0,
+            "slot": "305",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:54"
+          },
+          {
+            "label": "accumulatedTax",
+            "offset": 0,
+            "slot": "306",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:57"
+          },
+          {
+            "label": "version",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:59"
+          },
+          {
+            "label": "uniswapV2Router",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_contract(IUniswapV2Router02)2835",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:12"
+          },
+          {
+            "label": "uniswapV2Pair",
+            "offset": 0,
+            "slot": "309",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:14"
+          },
+          {
+            "label": "routerAddr",
+            "offset": 0,
+            "slot": "310",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:16"
+          },
+          {
+            "label": "minTaxForSell",
+            "offset": 0,
+            "slot": "311",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:22"
+          },
+          {
+            "label": "USDT",
+            "offset": 0,
+            "slot": "312",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:24"
+          },
+          {
+            "label": "inTriggerProcess",
+            "offset": 20,
+            "slot": "312",
+            "type": "t_bool",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:26"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)46_storage": {
+            "label": "uint256[46]",
+            "numberOfBytes": "1472"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IUniswapV2Router02)2835": {
+            "label": "contract IUniswapV2Router02",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Snapshots)4285_storage)": {
+            "label": "mapping(address => struct ERC20SnapshotUpgradeable.Snapshots)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Counter)993_storage": {
+            "label": "struct CountersUpgradeable.Counter",
+            "members": [
+              {
+                "label": "_value",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Snapshots)4285_storage": {
             "label": "struct ERC20SnapshotUpgradeable.Snapshots",
             "members": [
               {

--- a/.openzeppelin/unknown-42161.json
+++ b/.openzeppelin/unknown-42161.json
@@ -1355,6 +1355,368 @@
           }
         }
       }
+    },
+    "e7e34418ced41e296a71c2e9b322bcebce8886705747ffd4ebf60effb510299f": {
+      "address": "0x69721F872Ac905804AB2625dEDBEbDd7bc551820",
+      "txHash": "0xd5bf96fc6d928b705b143105c8d623e752f9b5008eda0d4f667c304f74fe0d66",
+      "layout": {
+        "solcVersion": "0.8.3",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:39"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:41"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:43"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:45"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:364"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20PausableUpgradeable",
+            "src": "contracts/oz/ERC20PausableUpgradeable.sol:46"
+          },
+          {
+            "label": "_accountBalanceSnapshots",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_mapping(t_address,t_struct(Snapshots)4793_storage)",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:55"
+          },
+          {
+            "label": "_totalSupplySnapshots",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_struct(Snapshots)4793_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:56"
+          },
+          {
+            "label": "_currentSnapshotId",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_struct(Counter)993_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:59"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_array(t_uint256)46_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:211"
+          },
+          {
+            "label": "authorizedToSnapshot",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:40"
+          },
+          {
+            "label": "buyTaxRate",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:45"
+          },
+          {
+            "label": "sellTaxRate",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:46"
+          },
+          {
+            "label": "poolsToTax",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:52"
+          },
+          {
+            "label": "taxTo",
+            "offset": 0,
+            "slot": "305",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:54"
+          },
+          {
+            "label": "accumulatedTax",
+            "offset": 0,
+            "slot": "306",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:57"
+          },
+          {
+            "label": "version",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:59"
+          },
+          {
+            "label": "uniswapV2Router",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_contract(IUniswapV2Router02)2835",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:13"
+          },
+          {
+            "label": "uniswapV2Pair",
+            "offset": 0,
+            "slot": "309",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:15"
+          },
+          {
+            "label": "routerAddr",
+            "offset": 0,
+            "slot": "310",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:17"
+          },
+          {
+            "label": "minTaxForSell",
+            "offset": 0,
+            "slot": "311",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:22"
+          },
+          {
+            "label": "USDT",
+            "offset": 0,
+            "slot": "312",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:25"
+          },
+          {
+            "label": "inTriggerProcess",
+            "offset": 20,
+            "slot": "312",
+            "type": "t_bool",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:27"
+          },
+          {
+            "label": "uniswapV3Router",
+            "offset": 0,
+            "slot": "313",
+            "type": "t_contract(IUniswapRouter02)4684",
+            "contract": "UniswapV3",
+            "src": "contracts/core/UniswapV3.sol:15"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)46_storage": {
+            "label": "uint256[46]",
+            "numberOfBytes": "1472"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IUniswapRouter02)4684": {
+            "label": "contract IUniswapRouter02",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IUniswapV2Router02)2835": {
+            "label": "contract IUniswapV2Router02",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Snapshots)4793_storage)": {
+            "label": "mapping(address => struct ERC20SnapshotUpgradeable.Snapshots)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Counter)993_storage": {
+            "label": "struct CountersUpgradeable.Counter",
+            "members": [
+              {
+                "label": "_value",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Snapshots)4793_storage": {
+            "label": "struct ERC20SnapshotUpgradeable.Snapshots",
+            "members": [
+              {
+                "label": "ids",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "values",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-42161.json
+++ b/.openzeppelin/unknown-42161.json
@@ -767,7 +767,7 @@
             "label": "_accountBalanceSnapshots",
             "offset": 0,
             "slot": "251",
-            "type": "t_mapping(t_address,t_struct(Snapshots)4285_storage)",
+            "type": "t_mapping(t_address,t_struct(Snapshots)4609_storage)",
             "contract": "ERC20SnapshotUpgradeable",
             "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:55"
           },
@@ -775,7 +775,7 @@
             "label": "_totalSupplySnapshots",
             "offset": 0,
             "slot": "252",
-            "type": "t_struct(Snapshots)4285_storage",
+            "type": "t_struct(Snapshots)4609_storage",
             "contract": "ERC20SnapshotUpgradeable",
             "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:56"
           },
@@ -857,7 +857,7 @@
             "slot": "308",
             "type": "t_contract(IUniswapV2Router02)2835",
             "contract": "Uniswap",
-            "src": "contracts/core/Uniswap.sol:12"
+            "src": "contracts/core/Uniswap.sol:13"
           },
           {
             "label": "uniswapV2Pair",
@@ -865,7 +865,7 @@
             "slot": "309",
             "type": "t_address",
             "contract": "Uniswap",
-            "src": "contracts/core/Uniswap.sol:14"
+            "src": "contracts/core/Uniswap.sol:15"
           },
           {
             "label": "routerAddr",
@@ -873,7 +873,7 @@
             "slot": "310",
             "type": "t_address",
             "contract": "Uniswap",
-            "src": "contracts/core/Uniswap.sol:16"
+            "src": "contracts/core/Uniswap.sol:17"
           },
           {
             "label": "minTaxForSell",
@@ -889,7 +889,7 @@
             "slot": "312",
             "type": "t_address",
             "contract": "BlocjerkTokenV5",
-            "src": "contracts/BlocjerkTokenV5.sol:24"
+            "src": "contracts/BlocjerkTokenV5.sol:25"
           },
           {
             "label": "inTriggerProcess",
@@ -897,7 +897,7 @@
             "slot": "312",
             "type": "t_bool",
             "contract": "BlocjerkTokenV5",
-            "src": "contracts/BlocjerkTokenV5.sol:26"
+            "src": "contracts/BlocjerkTokenV5.sol:27"
           }
         ],
         "types": {
@@ -941,7 +941,7 @@
             "label": "mapping(address => mapping(address => uint256))",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_address,t_struct(Snapshots)4285_storage)": {
+          "t_mapping(t_address,t_struct(Snapshots)4609_storage)": {
             "label": "mapping(address => struct ERC20SnapshotUpgradeable.Snapshots)",
             "numberOfBytes": "32"
           },
@@ -965,7 +965,369 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(Snapshots)4285_storage": {
+          "t_struct(Snapshots)4609_storage": {
+            "label": "struct ERC20SnapshotUpgradeable.Snapshots",
+            "members": [
+              {
+                "label": "ids",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "values",
+                "type": "t_array(t_uint256)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "d74d8eb4134c111051c4d860bbc2329449771a0e07d5bd229f32e303237ed2f4": {
+      "address": "0x1d490BbfE2f9e96a6A852fE6692A022d7fFB1105",
+      "txHash": "0x7dcdd37923494c415ab409e978d9d1da33b897abe4f537bf7629b66a53535fb9",
+      "layout": {
+        "solcVersion": "0.8.3",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:39"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:41"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_uint256",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:43"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:45"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_string_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:46"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ERC20Upgradeable",
+            "src": "contracts/oz/ERC20Upgradeable.sol:364"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC20PausableUpgradeable",
+            "src": "contracts/oz/ERC20PausableUpgradeable.sol:46"
+          },
+          {
+            "label": "_accountBalanceSnapshots",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_mapping(t_address,t_struct(Snapshots)4854_storage)",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:55"
+          },
+          {
+            "label": "_totalSupplySnapshots",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_struct(Snapshots)4854_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:56"
+          },
+          {
+            "label": "_currentSnapshotId",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_struct(Counter)993_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:59"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_array(t_uint256)46_storage",
+            "contract": "ERC20SnapshotUpgradeable",
+            "src": "contracts/oz/ERC20SnapshotUpgradeable.sol:211"
+          },
+          {
+            "label": "authorizedToSnapshot",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:40"
+          },
+          {
+            "label": "buyTaxRate",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:45"
+          },
+          {
+            "label": "sellTaxRate",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:46"
+          },
+          {
+            "label": "poolsToTax",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:52"
+          },
+          {
+            "label": "taxTo",
+            "offset": 0,
+            "slot": "305",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:54"
+          },
+          {
+            "label": "accumulatedTax",
+            "offset": 0,
+            "slot": "306",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:57"
+          },
+          {
+            "label": "version",
+            "offset": 0,
+            "slot": "307",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV4WithVersion",
+            "src": "contracts/BlocjerkTokenV4WithVersion.sol:59"
+          },
+          {
+            "label": "uniswapV2Router",
+            "offset": 0,
+            "slot": "308",
+            "type": "t_contract(IUniswapV2Router02)2835",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:13"
+          },
+          {
+            "label": "uniswapV2Pair",
+            "offset": 0,
+            "slot": "309",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:15"
+          },
+          {
+            "label": "routerAddr",
+            "offset": 0,
+            "slot": "310",
+            "type": "t_address",
+            "contract": "Uniswap",
+            "src": "contracts/core/Uniswap.sol:17"
+          },
+          {
+            "label": "minTaxForSell",
+            "offset": 0,
+            "slot": "311",
+            "type": "t_uint256",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:22"
+          },
+          {
+            "label": "USDT",
+            "offset": 0,
+            "slot": "312",
+            "type": "t_address",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:25"
+          },
+          {
+            "label": "inTriggerProcess",
+            "offset": 20,
+            "slot": "312",
+            "type": "t_bool",
+            "contract": "BlocjerkTokenV5",
+            "src": "contracts/BlocjerkTokenV5.sol:27"
+          },
+          {
+            "label": "uniswapV3Router",
+            "offset": 0,
+            "slot": "313",
+            "type": "t_contract(IUniswapRouter02)4745",
+            "contract": "UniswapV3",
+            "src": "contracts/core/UniswapV3.sol:15"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)46_storage": {
+            "label": "uint256[46]",
+            "numberOfBytes": "1472"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IUniswapRouter02)4745": {
+            "label": "contract IUniswapRouter02",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IUniswapV2Router02)2835": {
+            "label": "contract IUniswapV2Router02",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(Snapshots)4854_storage)": {
+            "label": "mapping(address => struct ERC20SnapshotUpgradeable.Snapshots)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Counter)993_storage": {
+            "label": "struct CountersUpgradeable.Counter",
+            "members": [
+              {
+                "label": "_value",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Snapshots)4854_storage": {
             "label": "struct ERC20SnapshotUpgradeable.Snapshots",
             "members": [
               {

--- a/README.md
+++ b/README.md
@@ -50,15 +50,15 @@ upgrade(
 
 Open $BJ contract on etherscan and confirm that contract was upgraded.
 
-## Operations TODO against BlocjerkTokenV5 upgrades
+## Operations TODO against BlocjerkTokenV6 upgrades
 
 NOTE: $BJ will be added liquidity on Uniswap V2 with $WETH
 
-- Call `addPoolToTax` or `removePoolToTax` to add or remove pools where takes tax fees of buying or selling
+- Call `addPoolToTax` or `removePoolToTax` to add or remove liquidity pools where takes tax fees of buying or selling
 - Call `setTaxTo` to set target address where tax fees will be transfered directly after swapping for WETH
 - Call `setMinTaxForSell` to set minimum tax fee amount to sell for ETH
-- Call `setRouter` to set Uniswap V2 Router and Pair address($BJ + $WETH)
-- Finally call `upgradeToV5` to mark all the setting is done
+- Call `setUniswapV2Router` to set Uniswap V2 Router and Pair address($BJ + $WETH)
+- Finally call `upgradeToV6` to mark all the setting is done
 
 
 ## Contract Addresses
@@ -70,7 +70,40 @@ Arbitrum | 0x9cAAe40DCF950aFEA443119e51E821D6FE2437ca
 
 ### Pools
 
-Network | Pair | Contract Address
+Network | Protocol | Pair | Contract Address
+--- | --- | --- | ---
+Ethereum | Uniswap V2 | $BJ+$WETH | 0x20dDbFd14F316D417f5B1a981B5Dc926a4dFd4D1
+Arbitrum | Camelot V2 | $BJ+$WETH | 0xFE9C07b7bE828e9E60975843Eb78B720D636Dad7
+Sepolia | Uniswap V2 | $BJ+$WETH | 0x0190512Ad8Be3Ff42063e12aB7E353A038c4ecF5
+Sepolia | Uniswap V3 | $BJ+$WETH(0.3%) | 0xA282B4fEbE16588F329fDc6c0aeeE76b896fBec0
+
+### Router
+
+Network | Name | Contract Address
 --- | --- | ---
-Ethereum | $BJ+$WETH | 0x20dDbFd14F316D417f5B1a981B5Dc926a4dFd4D1
-Sepolia | $BJ+$WETH | 0x0190512Ad8Be3Ff42063e12aB7E353A038c4ecF5
+Ethereum | Uniswap V2, UniswapV2Router02 | 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D
+Sepolia | Uniswap V2, UniswapV2Router02 | 0xC532a74256D3Db42D0Bf7a0400fEFDbad7694008
+Ethereum | Uniswap V3, SmartRouter02 | 0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45
+Arbitrum | Uniswap V3, SmartRouter02 | 0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45
+Arbitrum | Camelot V2, CamelotRouter | 0xc873fEcbd354f5A56E00E710B90EF4201db2448d
+
+
+## Development
+
+### Run test 
+
+```bash
+npm run test
+```
+
+### How to use tenderly
+
+Tenderly provides the nodes forked from the main nodes, such as Ethereum, Sepolia, etc.
+
+In order to run test or deployment on tenderly's forked node, execute the following commands
+
+```bash
+npm run test --network tenderlySepolia
+npm run deploy tenderlyMainnet
+npm run upgrade tenderlyMainnet
+```

--- a/contracts/BlocjerkTokenV4WithVersion.sol
+++ b/contracts/BlocjerkTokenV4WithVersion.sol
@@ -262,7 +262,7 @@ contract BlocjerkTokenV4WithVersion is
     uint256 buyTaxRate_,
     uint256 sellTaxRate_
   ) external onlyOwner {
-    require(buyTaxRate != buyTaxRate_ && sellTaxRate != sellTaxRate_);
+    require(buyTaxRate != buyTaxRate_ || sellTaxRate != sellTaxRate_);
 
     buyTaxRate = buyTaxRate_;
     sellTaxRate = sellTaxRate_;

--- a/contracts/BlocjerkTokenV5.sol
+++ b/contracts/BlocjerkTokenV5.sol
@@ -21,6 +21,7 @@ contract BlocjerkTokenV5 is BlocjerkTokenV4WithVersion, Uniswap {
   // immediately sell tax for ETH and send to taxTo address.
   uint256 public minTaxForSell;
 
+  // @deprecated, unused variable
   address public USDT;
 
   bool internal inTriggerProcess;
@@ -94,7 +95,11 @@ contract BlocjerkTokenV5 is BlocjerkTokenV4WithVersion, Uniswap {
     uint256 tokensSold;
     uint256 ethReceived;
 
-    if (taxTo != address(0) && tokenAmount > 0) {
+    if (
+      taxTo != address(0) &&
+      tokenAmount > 0 &&
+      address(uniswapV2Router) != address(0)
+    ) {
       // Must approve before swapping
       _approve(address(this), address(uniswapV2Router), tokenAmount);
 

--- a/contracts/BlocjerkTokenV5.sol
+++ b/contracts/BlocjerkTokenV5.sol
@@ -22,7 +22,7 @@ contract BlocjerkTokenV5 is BlocjerkTokenV4WithVersion, Uniswap {
   uint256 public minTaxForSell;
 
   // @deprecated, unused variable
-  address public USDT;
+  address internal USDT;
 
   bool internal inTriggerProcess;
   modifier lockTheProcess() {
@@ -36,15 +36,16 @@ contract BlocjerkTokenV5 is BlocjerkTokenV4WithVersion, Uniswap {
    * variables and execute other upgrade logic.
    * Ref: https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/62
    */
-  function upgradeToV5() external {
-    require(version < 5, "DeHubToken: Already upgraded to version 5");
-    version = 5;
-    console.log("v", version);
-  }
+  // function upgradeToV5() external {
+  //   require(version < 5, "DeHubToken: Already upgraded to version 5");
+  //   version = 5;
+  //   console.log("v", version);
+  // }
 
-  function setUSDT(address USDT_) external onlyOwner {
-    USDT = USDT_;
-  }
+  // @deprecated
+  // function setUSDT(address USDT_) external onlyOwner {
+  //   USDT = USDT_;
+  // }
 
   function setMinTaxForSell(uint256 minTaxForSell_) external onlyOwner {
     require(minTaxForSell != minTaxForSell_);

--- a/contracts/BlocjerkTokenV6.sol
+++ b/contracts/BlocjerkTokenV6.sol
@@ -23,26 +23,26 @@ contract BlocjerkTokenV6 is BlocjerkTokenV5, UniswapV3 {
     console.log("v", version);
   }
 
-  function _sellTax(
-    uint256 tokenAmount
-  ) internal virtual override lockTheProcess {
-    uint256 tokensSold;
-    uint256 ethReceived;
+  // function _sellTax(
+  //   uint256 tokenAmount
+  // ) internal virtual override lockTheProcess {
+  //   uint256 tokensSold;
+  //   uint256 ethReceived;
 
-    if (
-      taxTo != address(0) &&
-      tokenAmount > 0 &&
-      address(uniswapV3Router) != address(0)
-    ) {
-      ethReceived = swapExactInputSingle(
-        address(this),
-        uniswapV3Router.WETH9(),
-        taxTo,
-        3000, // 0.3%
-        tokenAmount
-      );
-      tokensSold = tokenAmount;
-    }
-    emit SoldTax(tokensSold, ethReceived);
-  }
+  //   if (
+  //     taxTo != address(0) &&
+  //     tokenAmount > 0 &&
+  //     address(uniswapV3Router) != address(0)
+  //   ) {
+  //     ethReceived = swapExactInputSingle(
+  //       address(this),
+  //       uniswapV3Router.WETH9(),
+  //       taxTo,
+  //       3000, // 0.3%
+  //       tokenAmount
+  //     );
+  //     tokensSold = tokenAmount;
+  //   }
+  //   emit SoldTax(tokensSold, ethReceived);
+  // }
 }

--- a/contracts/BlocjerkTokenV6.sol
+++ b/contracts/BlocjerkTokenV6.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.3;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {BlocjerkTokenV5} from "./BlocjerkTokenV5.sol";
+import {UniswapV3} from "./core/UniswapV3.sol";
+import {console} from "hardhat/console.sol";
+
+/**
+ * [Changes from BlocjerkTokenV5]
+ * - Sell accumulated tax fee for ETH through Uniswap V3 Router
+ *  and send ETH to taxTo wallet address when regular transfer
+ */
+contract BlocjerkTokenV6 is BlocjerkTokenV5, UniswapV3 {
+  /**
+   * @dev Must call this just after the upgrade deployment, to update state
+   * variables and execute other upgrade logic.
+   * Ref: https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/62
+   */
+  function upgradeToV6() external {
+    require(version < 6, "DeHubToken: Already upgraded to version 6");
+    version = 6;
+    console.log("v", version);
+  }
+
+  function _sellTax(
+    uint256 tokenAmount
+  ) internal virtual override lockTheProcess {
+    uint256 tokensSold;
+    uint256 ethReceived;
+
+    if (
+      taxTo != address(0) &&
+      tokenAmount > 0 &&
+      address(uniswapV3Router) != address(0)
+    ) {
+      ethReceived = swapExactInputSingle(
+        address(this),
+        uniswapV3Router.WETH9(),
+        taxTo,
+        3000, // 0.3%
+        tokenAmount
+      );
+      tokensSold = tokenAmount;
+    }
+    emit SoldTax(tokensSold, ethReceived);
+  }
+}

--- a/contracts/core/Uniswap.sol
+++ b/contracts/core/Uniswap.sol
@@ -19,7 +19,7 @@ abstract contract Uniswap is OwnableUpgradeable {
   // To receive ETH from uniswapV2Router when swaping
   receive() external payable {}
 
-  function setRouter(address router, address pair) external onlyOwner {
+  function setUniswapV2Router(address router, address pair) external onlyOwner {
     require(router != address(0));
     uniswapV2Router = IUniswapV2Router02(router);
     uniswapV2Pair = pair;

--- a/contracts/core/UniswapV3.sol
+++ b/contracts/core/UniswapV3.sol
@@ -9,6 +9,7 @@ import {IUniswapRouter02} from "../interfaces/IUniswapRouter02.sol";
 
 abstract contract UniswapV3 is OwnableUpgradeable {
   // Mainnet: 0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45
+  // Sepolia: 0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E
   // Address to SwapRouter02
   // https://github.com/Uniswap/swap-router-contracts/blob/main/contracts/SwapRouter02.sol
   IUniswapRouter02 internal uniswapV3Router;
@@ -27,14 +28,6 @@ abstract contract UniswapV3 is OwnableUpgradeable {
     uint amountIn
   ) internal returns (uint amountOut) {
     if (address(uniswapV3Router) != address(0)) {
-      TransferHelper.safeTransferFrom(
-        tokenIn,
-        msg.sender,
-        address(this),
-        amountIn
-      );
-
-      // Approve the router to spend DAI.
       TransferHelper.safeApprove(tokenIn, address(uniswapV3Router), amountIn);
 
       IUniswapRouter02.ExactInputSingleParams memory params = IUniswapRouter02

--- a/contracts/core/UniswapV3.sol
+++ b/contracts/core/UniswapV3.sol
@@ -13,7 +13,7 @@ abstract contract UniswapV3 is OwnableUpgradeable {
   // https://github.com/Uniswap/swap-router-contracts/blob/main/contracts/SwapRouter02.sol
   IUniswapRouter02 internal uniswapV3Router;
 
-  function setUniswapV3Router(address router) external {
+  function setUniswapV3Router(address router) external onlyOwner {
     require(router != address(0));
     uniswapV3Router = IUniswapRouter02(router);
     emit UniswapV3RouterSet(router);

--- a/contracts/core/UniswapV3.sol
+++ b/contracts/core/UniswapV3.sol
@@ -6,8 +6,7 @@ import {IUniswapV2Router02} from "@uniswap/v2-periphery/contracts/interfaces/IUn
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {SafeMathUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 
-// @deprecated
-abstract contract Uniswap is OwnableUpgradeable {
+abstract contract UniswapV3 is OwnableUpgradeable {
   using SafeMathUpgradeable for uint256;
   // Using Uniswap lib, because Uniswap forks are trash ATM...
   IUniswapV2Router02 internal uniswapV2Router;
@@ -19,11 +18,10 @@ abstract contract Uniswap is OwnableUpgradeable {
   // To receive ETH from uniswapV2Router when swaping
   receive() external payable {}
 
-  function setRouter(address router, address pair) external onlyOwner {
+  function setRouter(address router) external onlyOwner {
     require(router != address(0));
     uniswapV2Router = IUniswapV2Router02(router);
-    uniswapV2Pair = pair;
-    emit RouterSet(router, pair);
+    emit UniswapV2RouterSet(router);
   }
 
   /**
@@ -72,7 +70,8 @@ abstract contract Uniswap is OwnableUpgradeable {
   }
 
   /* --------------------------------- Events --------------------------------- */
-  event RouterSet(address indexed router, address indexed pair);
+  event UniswapV2RouterSet(address indexed router);
+  event UniswapV3RouterSet(address indexed router);
 
   /* -------------------------------- Modifiers ------------------------------- */
   modifier pcsInitialized() {

--- a/contracts/interfaces/IUniswapRouter02.sol
+++ b/contracts/interfaces/IUniswapRouter02.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title Router token swapping functionality, SwapRouter02
+///        https://github.com/Uniswap/swap-router-contracts/blob/main/contracts/SwapRouter02.sol
+/// @notice Functions for swapping tokens via Uniswap V3
+interface IUniswapRouter02 {
+  struct ExactInputSingleParams {
+    address tokenIn;
+    address tokenOut;
+    uint24 fee;
+    address recipient;
+    uint256 amountIn;
+    uint256 amountOutMinimum;
+    uint160 sqrtPriceLimitX96;
+  }
+
+  /// @notice Swaps `amountIn` of one token for as much as possible of another token
+  /// @dev Setting `amountIn` to 0 will cause the contract to look up its own balance,
+  /// and swap the entire amount, enabling contracts to send tokens before calling this function.
+  /// @param params The parameters necessary for the swap, encoded as `ExactInputSingleParams` in calldata
+  /// @return amountOut The amount of the received token
+  function exactInputSingle(
+    ExactInputSingleParams calldata params
+  ) external payable returns (uint256 amountOut);
+
+  struct ExactInputParams {
+    bytes path;
+    address recipient;
+    uint256 amountIn;
+    uint256 amountOutMinimum;
+  }
+
+  /// @notice Swaps `amountIn` of one token for as much as possible of another along the specified path
+  /// @dev Setting `amountIn` to 0 will cause the contract to look up its own balance,
+  /// and swap the entire amount, enabling contracts to send tokens before calling this function.
+  /// @param params The parameters necessary for the multi-hop swap, encoded as `ExactInputParams` in calldata
+  /// @return amountOut The amount of the received token
+  function exactInput(
+    ExactInputParams calldata params
+  ) external payable returns (uint256 amountOut);
+
+  struct ExactOutputSingleParams {
+    address tokenIn;
+    address tokenOut;
+    uint24 fee;
+    address recipient;
+    uint256 amountOut;
+    uint256 amountInMaximum;
+    uint160 sqrtPriceLimitX96;
+  }
+
+  /// @notice Swaps as little as possible of one token for `amountOut` of another token
+  /// that may remain in the router after the swap.
+  /// @param params The parameters necessary for the swap, encoded as `ExactOutputSingleParams` in calldata
+  /// @return amountIn The amount of the input token
+  function exactOutputSingle(
+    ExactOutputSingleParams calldata params
+  ) external payable returns (uint256 amountIn);
+
+  struct ExactOutputParams {
+    bytes path;
+    address recipient;
+    uint256 amountOut;
+    uint256 amountInMaximum;
+  }
+
+  /// @notice Swaps as little as possible of one token for `amountOut` of another along the specified path (reversed)
+  /// that may remain in the router after the swap.
+  /// @param params The parameters necessary for the multi-hop swap, encoded as `ExactOutputParams` in calldata
+  /// @return amountIn The amount of the input token
+  function exactOutput(
+    ExactOutputParams calldata params
+  ) external payable returns (uint256 amountIn);
+}

--- a/contracts/interfaces/IUniswapRouter02.sol
+++ b/contracts/interfaces/IUniswapRouter02.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {IPeripheryImmutableState} from "@uniswap/v3-periphery/contracts/interfaces/IPeripheryImmutableState.sol";
+
 /// @title Router token swapping functionality, SwapRouter02
 ///        https://github.com/Uniswap/swap-router-contracts/blob/main/contracts/SwapRouter02.sol
 /// @notice Functions for swapping tokens via Uniswap V3
-interface IUniswapRouter02 {
+interface IUniswapRouter02 is IPeripheryImmutableState {
   struct ExactInputSingleParams {
     address tokenIn;
     address tokenOut;

--- a/contracts/tests/TestUniswapV3.sol
+++ b/contracts/tests/TestUniswapV3.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {ISwapRouter} from "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
 import {TransferHelper} from "@uniswap/v3-periphery/contracts/libraries/TransferHelper.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IUniswapRouter02} from "../interfaces/IUniswapRouter02.sol";
 
 interface IWETH is IERC20 {
   function deposit() external payable;
@@ -13,11 +13,12 @@ interface IWETH is IERC20 {
 }
 
 contract TestUniswapV3 is Ownable {
-  ISwapRouter internal uniswapV3Router;
+  // Address to SwapRouter02
+  IUniswapRouter02 internal uniswapV3Router;
 
   function setUniswapV3Router(address router) external onlyOwner {
     require(router != address(0));
-    uniswapV3Router = ISwapRouter(router);
+    uniswapV3Router = IUniswapRouter02(router);
   }
 
   function swapExactInputSingle(
@@ -42,13 +43,12 @@ contract TestUniswapV3 is Ownable {
       //IERC20(tokenIn).transferFrom(msg.sender, address(this), amountIn);
       //IERC20(tokenIn).approve(address(router), amountIn);
 
-      ISwapRouter.ExactInputSingleParams memory params = ISwapRouter
+      IUniswapRouter02.ExactInputSingleParams memory params = IUniswapRouter02
         .ExactInputSingleParams({
           tokenIn: tokenIn,
           tokenOut: tokenOut,
           fee: poolFee,
           recipient: recipient,
-          deadline: block.timestamp,
           amountIn: amountIn,
           amountOutMinimum: 0,
           sqrtPriceLimitX96: 0

--- a/contracts/tests/TestUniswapV3.sol
+++ b/contracts/tests/TestUniswapV3.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {ISwapRouter} from "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
+import {TransferHelper} from "@uniswap/v3-periphery/contracts/libraries/TransferHelper.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IWETH is IERC20 {
+  function deposit() external payable;
+
+  function withdraw(uint amount) external;
+}
+
+contract TestUniswapV3 is Ownable {
+  ISwapRouter internal uniswapV3Router;
+
+  function setUniswapV3Router(address router) external onlyOwner {
+    require(router != address(0));
+    uniswapV3Router = ISwapRouter(router);
+  }
+
+  function swapExactInputSingle(
+    address tokenIn,
+    address tokenOut,
+    address recipient,
+    uint24 poolFee,
+    uint amountIn
+  ) external returns (uint256 amountOut) {
+    if (address(uniswapV3Router) != address(0)) {
+      // Transfer the specified amount of DAI to this contract.
+      TransferHelper.safeTransferFrom(
+        tokenIn,
+        msg.sender,
+        address(this),
+        amountIn
+      );
+
+      // Approve the router to spend DAI.
+      TransferHelper.safeApprove(tokenIn, address(uniswapV3Router), amountIn);
+
+      //IERC20(tokenIn).transferFrom(msg.sender, address(this), amountIn);
+      //IERC20(tokenIn).approve(address(router), amountIn);
+
+      ISwapRouter.ExactInputSingleParams memory params = ISwapRouter
+        .ExactInputSingleParams({
+          tokenIn: tokenIn,
+          tokenOut: tokenOut,
+          fee: poolFee,
+          recipient: recipient,
+          deadline: block.timestamp,
+          amountIn: amountIn,
+          amountOutMinimum: 0,
+          sqrtPriceLimitX96: 0
+        });
+
+      amountOut = uniswapV3Router.exactInputSingle(params);
+    }
+  }
+}

--- a/flatten/BlocjerkTokenV6.sol
+++ b/flatten/BlocjerkTokenV6.sol
@@ -1,0 +1,3745 @@
+pragma solidity ^0.8.3;
+
+
+interface IERC20 {
+    
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    
+    function totalSupply() external view returns (uint256);
+
+    
+    function balanceOf(address account) external view returns (uint256);
+
+    
+    function transfer(address to, uint256 amount) external returns (bool);
+
+    
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    
+    function transferFrom(
+        address from,
+        address to,
+        uint256 amount
+    ) external returns (bool);
+}
+
+interface IERC20Upgradeable {
+    
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    
+    function totalSupply() external view returns (uint256);
+
+    
+    function balanceOf(address account) external view returns (uint256);
+
+    
+    function transfer(address to, uint256 amount) external returns (bool);
+
+    
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    
+    function transferFrom(
+        address from,
+        address to,
+        uint256 amount
+    ) external returns (bool);
+}
+
+library AddressUpgradeable {
+    
+    function isContract(address account) internal view returns (bool) {
+        
+        
+        
+
+        return account.code.length > 0;
+    }
+
+    
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        (bool success, ) = recipient.call{value: amount}("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, 0, "Address: low-level call failed");
+    }
+
+    
+    function functionCall(
+        address target,
+        bytes memory data,
+        string memory errorMessage
+    ) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    
+    function functionCallWithValue(
+        address target,
+        bytes memory data,
+        uint256 value
+    ) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    
+    function functionCallWithValue(
+        address target,
+        bytes memory data,
+        uint256 value,
+        string memory errorMessage
+    ) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        (bool success, bytes memory returndata) = target.call{value: value}(data);
+        return verifyCallResultFromTarget(target, success, returndata, errorMessage);
+    }
+
+    
+    function functionStaticCall(address target, bytes memory data) internal view returns (bytes memory) {
+        return functionStaticCall(target, data, "Address: low-level static call failed");
+    }
+
+    
+    function functionStaticCall(
+        address target,
+        bytes memory data,
+        string memory errorMessage
+    ) internal view returns (bytes memory) {
+        (bool success, bytes memory returndata) = target.staticcall(data);
+        return verifyCallResultFromTarget(target, success, returndata, errorMessage);
+    }
+
+    
+    function verifyCallResultFromTarget(
+        address target,
+        bool success,
+        bytes memory returndata,
+        string memory errorMessage
+    ) internal view returns (bytes memory) {
+        if (success) {
+            if (returndata.length == 0) {
+                
+                
+                require(isContract(target), "Address: call to non-contract");
+            }
+            return returndata;
+        } else {
+            _revert(returndata, errorMessage);
+        }
+    }
+
+    
+    function verifyCallResult(
+        bool success,
+        bytes memory returndata,
+        string memory errorMessage
+    ) internal pure returns (bytes memory) {
+        if (success) {
+            return returndata;
+        } else {
+            _revert(returndata, errorMessage);
+        }
+    }
+
+    function _revert(bytes memory returndata, string memory errorMessage) private pure {
+        
+        if (returndata.length > 0) {
+            
+            
+            assembly {
+                let returndata_size := mload(returndata)
+                revert(add(32, returndata), returndata_size)
+            }
+        } else {
+            revert(errorMessage);
+        }
+    }
+}
+
+abstract contract Initializable {
+    
+    uint8 private _initialized;
+
+    
+    bool private _initializing;
+
+    
+    event Initialized(uint8 version);
+
+    
+    modifier initializer() {
+        bool isTopLevelCall = !_initializing;
+        require(
+            (isTopLevelCall && _initialized < 1) || (!AddressUpgradeable.isContract(address(this)) && _initialized == 1),
+            "Initializable: contract is already initialized"
+        );
+        _initialized = 1;
+        if (isTopLevelCall) {
+            _initializing = true;
+        }
+        _;
+        if (isTopLevelCall) {
+            _initializing = false;
+            emit Initialized(1);
+        }
+    }
+
+    
+    modifier reinitializer(uint8 version) {
+        require(!_initializing && _initialized < version, "Initializable: contract is already initialized");
+        _initialized = version;
+        _initializing = true;
+        _;
+        _initializing = false;
+        emit Initialized(version);
+    }
+
+    
+    modifier onlyInitializing() {
+        require(_initializing, "Initializable: contract is not initializing");
+        _;
+    }
+
+    
+    function _disableInitializers() internal virtual {
+        require(!_initializing, "Initializable: contract is initializing");
+        if (_initialized < type(uint8).max) {
+            _initialized = type(uint8).max;
+            emit Initialized(type(uint8).max);
+        }
+    }
+
+    
+    function _getInitializedVersion() internal view returns (uint8) {
+        return _initialized;
+    }
+
+    
+    function _isInitializing() internal view returns (bool) {
+        return _initializing;
+    }
+}
+
+abstract contract ContextUpgradeable is Initializable {
+    function __Context_init() internal onlyInitializing {
+    }
+
+    function __Context_init_unchained() internal onlyInitializing {
+    }
+    function _msgSender() internal view virtual returns (address) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes calldata) {
+        return msg.data;
+    }
+
+    
+    uint256[50] private __gap;
+}
+
+contract ERC20Upgradeable is
+  Initializable,
+  ContextUpgradeable,
+  IERC20Upgradeable {
+  
+  mapping(address => uint256) internal _balances;
+
+  mapping(address => mapping(address => uint256)) internal _allowances;
+
+  uint256 private _totalSupply;
+
+  string private _name;
+  string private _symbol;
+
+  
+  function __ERC20_init(
+    string memory name_,
+    string memory symbol_
+  ) internal initializer {
+    __Context_init_unchained();
+    __ERC20_init_unchained(name_, symbol_);
+  }
+
+  function __ERC20_init_unchained(
+    string memory name_,
+    string memory symbol_
+  ) internal initializer {
+    _name = name_;
+    _symbol = symbol_;
+  }
+
+  
+  function name() public view virtual returns (string memory) {
+    return _name;
+  }
+
+  
+  function symbol() public view virtual returns (string memory) {
+    return _symbol;
+  }
+
+  
+  function decimals() public view virtual returns (uint8) {
+    return 18;
+  }
+
+  
+  function totalSupply() public view virtual override returns (uint256) {
+    return _totalSupply;
+  }
+
+  
+  function balanceOf(
+    address account
+  ) public view virtual override returns (uint256) {
+    return _balances[account];
+  }
+
+  
+  function transfer(
+    address recipient,
+    uint256 amount
+  ) public virtual override returns (bool) {
+    _transfer(_msgSender(), recipient, amount);
+    return true;
+  }
+
+  
+  function allowance(
+    address owner,
+    address spender
+  ) public view virtual override returns (uint256) {
+    return _allowances[owner][spender];
+  }
+
+  
+  function approve(
+    address spender,
+    uint256 amount
+  ) public virtual override returns (bool) {
+    _approve(_msgSender(), spender, amount);
+    return true;
+  }
+
+  
+  function transferFrom(
+    address sender,
+    address recipient,
+    uint256 amount
+  ) public virtual override returns (bool) {
+    _transfer(sender, recipient, amount);
+
+    uint256 currentAllowance = _allowances[sender][_msgSender()];
+    require(
+      currentAllowance >= amount,
+      "ERC20: transfer amount exceeds allowance"
+    );
+    _approve(sender, _msgSender(), currentAllowance - amount);
+
+    return true;
+  }
+
+  
+  function increaseAllowance(
+    address spender,
+    uint256 addedValue
+  ) public virtual returns (bool) {
+    _approve(
+      _msgSender(),
+      spender,
+      _allowances[_msgSender()][spender] + addedValue
+    );
+    return true;
+  }
+
+  
+  function decreaseAllowance(
+    address spender,
+    uint256 subtractedValue
+  ) public virtual returns (bool) {
+    uint256 currentAllowance = _allowances[_msgSender()][spender];
+    require(
+      currentAllowance >= subtractedValue,
+      "ERC20: decreased allowance below zero"
+    );
+    _approve(_msgSender(), spender, currentAllowance - subtractedValue);
+
+    return true;
+  }
+
+  
+  function _transfer(
+    address sender,
+    address recipient,
+    uint256 amount
+  ) internal virtual {
+    require(sender != address(0), "ERC20: transfer from the zero address");
+    require(recipient != address(0), "ERC20: transfer to the zero address");
+
+    _beforeTokenTransfer(sender, recipient, amount);
+
+    uint256 senderBalance = _balances[sender];
+    require(senderBalance >= amount, "ERC20: transfer amount exceeds balance");
+    _balances[sender] = senderBalance - amount;
+    _balances[recipient] += amount;
+
+    emit Transfer(sender, recipient, amount);
+  }
+
+  
+  function _mint(address account, uint256 amount) internal virtual {
+    require(account != address(0), "ERC20: mint to the zero address");
+
+    _beforeTokenTransfer(address(0), account, amount);
+
+    _totalSupply += amount;
+    _balances[account] += amount;
+    emit Transfer(address(0), account, amount);
+  }
+
+  
+  function _burn(address account, uint256 amount) internal virtual {
+    require(account != address(0), "ERC20: burn from the zero address");
+
+    _beforeTokenTransfer(account, address(0), amount);
+
+    uint256 accountBalance = _balances[account];
+    require(accountBalance >= amount, "ERC20: burn amount exceeds balance");
+    _balances[account] = accountBalance - amount;
+    _totalSupply -= amount;
+
+    emit Transfer(account, address(0), amount);
+  }
+
+  
+  function _approve(
+    address owner,
+    address spender,
+    uint256 amount
+  ) internal virtual {
+    require(owner != address(0), "ERC20: approve from the zero address");
+    require(spender != address(0), "ERC20: approve to the zero address");
+
+    _allowances[owner][spender] = amount;
+    emit Approval(owner, spender, amount);
+  }
+
+  
+  function _beforeTokenTransfer(
+    address from,
+    address to,
+    uint256 amount
+  ) internal virtual {}
+
+  uint256[45] private __gap;
+}
+
+library StorageSlotUpgradeable {
+    struct AddressSlot {
+        address value;
+    }
+
+    struct BooleanSlot {
+        bool value;
+    }
+
+    struct Bytes32Slot {
+        bytes32 value;
+    }
+
+    struct Uint256Slot {
+        uint256 value;
+    }
+
+    
+    function getAddressSlot(bytes32 slot) internal pure returns (AddressSlot storage r) {
+        
+        assembly {
+            r.slot := slot
+        }
+    }
+
+    
+    function getBooleanSlot(bytes32 slot) internal pure returns (BooleanSlot storage r) {
+        
+        assembly {
+            r.slot := slot
+        }
+    }
+
+    
+    function getBytes32Slot(bytes32 slot) internal pure returns (Bytes32Slot storage r) {
+        
+        assembly {
+            r.slot := slot
+        }
+    }
+
+    
+    function getUint256Slot(bytes32 slot) internal pure returns (Uint256Slot storage r) {
+        
+        assembly {
+            r.slot := slot
+        }
+    }
+}
+
+library MathUpgradeable {
+    enum Rounding {
+        Down, 
+        Up, 
+        Zero 
+    }
+
+    
+    function max(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a > b ? a : b;
+    }
+
+    
+    function min(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a < b ? a : b;
+    }
+
+    
+    function average(uint256 a, uint256 b) internal pure returns (uint256) {
+        
+        return (a & b) + (a ^ b) / 2;
+    }
+
+    
+    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {
+        
+        return a == 0 ? 0 : (a - 1) / b + 1;
+    }
+
+    
+    function mulDiv(
+        uint256 x,
+        uint256 y,
+        uint256 denominator
+    ) internal pure returns (uint256 result) {
+        unchecked {
+            
+            
+            
+            uint256 prod0; 
+            uint256 prod1; 
+            assembly {
+                let mm := mulmod(x, y, not(0))
+                prod0 := mul(x, y)
+                prod1 := sub(sub(mm, prod0), lt(mm, prod0))
+            }
+
+            
+            if (prod1 == 0) {
+                return prod0 / denominator;
+            }
+
+            
+            require(denominator > prod1);
+
+            
+            
+            
+
+            
+            uint256 remainder;
+            assembly {
+                
+                remainder := mulmod(x, y, denominator)
+
+                
+                prod1 := sub(prod1, gt(remainder, prod0))
+                prod0 := sub(prod0, remainder)
+            }
+
+            
+            
+
+            
+            uint256 twos = denominator & (~denominator + 1);
+            assembly {
+                
+                denominator := div(denominator, twos)
+
+                
+                prod0 := div(prod0, twos)
+
+                
+                twos := add(div(sub(0, twos), twos), 1)
+            }
+
+            
+            prod0 |= prod1 * twos;
+
+            
+            
+            
+            uint256 inverse = (3 * denominator) ^ 2;
+
+            
+            
+            inverse *= 2 - denominator * inverse; 
+            inverse *= 2 - denominator * inverse; 
+            inverse *= 2 - denominator * inverse; 
+            inverse *= 2 - denominator * inverse; 
+            inverse *= 2 - denominator * inverse; 
+            inverse *= 2 - denominator * inverse; 
+
+            
+            
+            
+            
+            result = prod0 * inverse;
+            return result;
+        }
+    }
+
+    
+    function mulDiv(
+        uint256 x,
+        uint256 y,
+        uint256 denominator,
+        Rounding rounding
+    ) internal pure returns (uint256) {
+        uint256 result = mulDiv(x, y, denominator);
+        if (rounding == Rounding.Up && mulmod(x, y, denominator) > 0) {
+            result += 1;
+        }
+        return result;
+    }
+
+    
+    function sqrt(uint256 a) internal pure returns (uint256) {
+        if (a == 0) {
+            return 0;
+        }
+
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        uint256 result = 1 << (log2(a) >> 1);
+
+        
+        
+        
+        
+        unchecked {
+            result = (result + a / result) >> 1;
+            result = (result + a / result) >> 1;
+            result = (result + a / result) >> 1;
+            result = (result + a / result) >> 1;
+            result = (result + a / result) >> 1;
+            result = (result + a / result) >> 1;
+            result = (result + a / result) >> 1;
+            return min(result, a / result);
+        }
+    }
+
+    
+    function sqrt(uint256 a, Rounding rounding) internal pure returns (uint256) {
+        unchecked {
+            uint256 result = sqrt(a);
+            return result + (rounding == Rounding.Up && result * result < a ? 1 : 0);
+        }
+    }
+
+    
+    function log2(uint256 value) internal pure returns (uint256) {
+        uint256 result = 0;
+        unchecked {
+            if (value >> 128 > 0) {
+                value >>= 128;
+                result += 128;
+            }
+            if (value >> 64 > 0) {
+                value >>= 64;
+                result += 64;
+            }
+            if (value >> 32 > 0) {
+                value >>= 32;
+                result += 32;
+            }
+            if (value >> 16 > 0) {
+                value >>= 16;
+                result += 16;
+            }
+            if (value >> 8 > 0) {
+                value >>= 8;
+                result += 8;
+            }
+            if (value >> 4 > 0) {
+                value >>= 4;
+                result += 4;
+            }
+            if (value >> 2 > 0) {
+                value >>= 2;
+                result += 2;
+            }
+            if (value >> 1 > 0) {
+                result += 1;
+            }
+        }
+        return result;
+    }
+
+    
+    function log2(uint256 value, Rounding rounding) internal pure returns (uint256) {
+        unchecked {
+            uint256 result = log2(value);
+            return result + (rounding == Rounding.Up && 1 << result < value ? 1 : 0);
+        }
+    }
+
+    
+    function log10(uint256 value) internal pure returns (uint256) {
+        uint256 result = 0;
+        unchecked {
+            if (value >= 10**64) {
+                value /= 10**64;
+                result += 64;
+            }
+            if (value >= 10**32) {
+                value /= 10**32;
+                result += 32;
+            }
+            if (value >= 10**16) {
+                value /= 10**16;
+                result += 16;
+            }
+            if (value >= 10**8) {
+                value /= 10**8;
+                result += 8;
+            }
+            if (value >= 10**4) {
+                value /= 10**4;
+                result += 4;
+            }
+            if (value >= 10**2) {
+                value /= 10**2;
+                result += 2;
+            }
+            if (value >= 10**1) {
+                result += 1;
+            }
+        }
+        return result;
+    }
+
+    
+    function log10(uint256 value, Rounding rounding) internal pure returns (uint256) {
+        unchecked {
+            uint256 result = log10(value);
+            return result + (rounding == Rounding.Up && 10**result < value ? 1 : 0);
+        }
+    }
+
+    
+    function log256(uint256 value) internal pure returns (uint256) {
+        uint256 result = 0;
+        unchecked {
+            if (value >> 128 > 0) {
+                value >>= 128;
+                result += 16;
+            }
+            if (value >> 64 > 0) {
+                value >>= 64;
+                result += 8;
+            }
+            if (value >> 32 > 0) {
+                value >>= 32;
+                result += 4;
+            }
+            if (value >> 16 > 0) {
+                value >>= 16;
+                result += 2;
+            }
+            if (value >> 8 > 0) {
+                result += 1;
+            }
+        }
+        return result;
+    }
+
+    
+    function log256(uint256 value, Rounding rounding) internal pure returns (uint256) {
+        unchecked {
+            uint256 result = log256(value);
+            return result + (rounding == Rounding.Up && 1 << (result * 8) < value ? 1 : 0);
+        }
+    }
+}
+
+library ArraysUpgradeable {
+    using StorageSlotUpgradeable for bytes32;
+
+    
+    function findUpperBound(uint256[] storage array, uint256 element) internal view returns (uint256) {
+        if (array.length == 0) {
+            return 0;
+        }
+
+        uint256 low = 0;
+        uint256 high = array.length;
+
+        while (low < high) {
+            uint256 mid = MathUpgradeable.average(low, high);
+
+            
+            
+            if (unsafeAccess(array, mid).value > element) {
+                high = mid;
+            } else {
+                low = mid + 1;
+            }
+        }
+
+        
+        if (low > 0 && unsafeAccess(array, low - 1).value == element) {
+            return low - 1;
+        } else {
+            return low;
+        }
+    }
+
+    
+    function unsafeAccess(address[] storage arr, uint256 pos) internal pure returns (StorageSlotUpgradeable.AddressSlot storage) {
+        bytes32 slot;
+        
+        assembly {
+            mstore(0, arr.slot)
+            slot := add(keccak256(0, 0x20), pos)
+        }
+        return slot.getAddressSlot();
+    }
+
+    
+    function unsafeAccess(bytes32[] storage arr, uint256 pos) internal pure returns (StorageSlotUpgradeable.Bytes32Slot storage) {
+        bytes32 slot;
+        
+        assembly {
+            mstore(0, arr.slot)
+            slot := add(keccak256(0, 0x20), pos)
+        }
+        return slot.getBytes32Slot();
+    }
+
+    
+    function unsafeAccess(uint256[] storage arr, uint256 pos) internal pure returns (StorageSlotUpgradeable.Uint256Slot storage) {
+        bytes32 slot;
+        
+        assembly {
+            mstore(0, arr.slot)
+            slot := add(keccak256(0, 0x20), pos)
+        }
+        return slot.getUint256Slot();
+    }
+}
+
+library CountersUpgradeable {
+    struct Counter {
+        
+        
+        
+        uint256 _value; 
+    }
+
+    function current(Counter storage counter) internal view returns (uint256) {
+        return counter._value;
+    }
+
+    function increment(Counter storage counter) internal {
+        unchecked {
+            counter._value += 1;
+        }
+    }
+
+    function decrement(Counter storage counter) internal {
+        uint256 value = counter._value;
+        require(value > 0, "Counter: decrement overflow");
+        unchecked {
+            counter._value = value - 1;
+        }
+    }
+
+    function reset(Counter storage counter) internal {
+        counter._value = 0;
+    }
+}
+
+abstract contract ERC20SnapshotUpgradeable is Initializable, ERC20Upgradeable {
+  function __ERC20Snapshot_init() internal initializer {
+    __Context_init_unchained();
+    __ERC20Snapshot_init_unchained();
+  }
+
+  function __ERC20Snapshot_init_unchained() internal initializer {}
+
+  
+  
+
+  using ArraysUpgradeable for uint256[];
+  using CountersUpgradeable for CountersUpgradeable.Counter;
+
+  
+  
+  struct Snapshots {
+    uint256[] ids;
+    uint256[] values;
+  }
+
+  mapping(address => Snapshots) private _accountBalanceSnapshots;
+  Snapshots private _totalSupplySnapshots;
+
+  
+  CountersUpgradeable.Counter private _currentSnapshotId;
+
+  
+  event Snapshot(uint256 id);
+
+  
+  function _snapshot() internal virtual returns (uint256) {
+    _currentSnapshotId.increment();
+
+    uint256 currentId = _currentSnapshotId.current();
+    emit Snapshot(currentId);
+    return currentId;
+  }
+
+  
+  function balanceOfAt(
+    address account,
+    uint256 snapshotId
+  ) public view virtual returns (uint256) {
+    (bool snapshotted, uint256 value) = _valueAt(
+      snapshotId,
+      _accountBalanceSnapshots[account]
+    );
+
+    return snapshotted ? value : balanceOf(account);
+  }
+
+  
+  function totalSupplyAt(
+    uint256 snapshotId
+  ) public view virtual returns (uint256) {
+    (bool snapshotted, uint256 value) = _valueAt(
+      snapshotId,
+      _totalSupplySnapshots
+    );
+
+    return snapshotted ? value : totalSupply();
+  }
+
+  
+  
+  function _beforeTokenTransfer(
+    address from,
+    address to,
+    uint256 amount
+  ) internal virtual override {
+    super._beforeTokenTransfer(from, to, amount);
+
+    if (from == address(0)) {
+      
+      _updateAccountSnapshot(to);
+      _updateTotalSupplySnapshot();
+    } else if (to == address(0)) {
+      
+      _updateAccountSnapshot(from);
+      _updateTotalSupplySnapshot();
+    } else {
+      
+      _updateAccountSnapshot(from);
+      _updateAccountSnapshot(to);
+    }
+  }
+
+  function _valueAt(
+    uint256 snapshotId,
+    Snapshots storage snapshots
+  ) private view returns (bool, uint256) {
+    require(snapshotId > 0, "ERC20Snapshot: id is 0");
+    
+    require(
+      snapshotId <= _currentSnapshotId.current(),
+      "ERC20Snapshot: nonexistent id"
+    );
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    uint256 index = snapshots.ids.findUpperBound(snapshotId);
+
+    if (index == snapshots.ids.length) {
+      return (false, 0);
+    } else {
+      return (true, snapshots.values[index]);
+    }
+  }
+
+  function _updateAccountSnapshot(address account) internal {
+    _updateSnapshot(_accountBalanceSnapshots[account], balanceOf(account));
+  }
+
+  function _updateTotalSupplySnapshot() internal {
+    _updateSnapshot(_totalSupplySnapshots, totalSupply());
+  }
+
+  function _updateSnapshot(
+    Snapshots storage snapshots,
+    uint256 currentValue
+  ) private {
+    uint256 currentId = _currentSnapshotId.current();
+    if (_lastSnapshotId(snapshots.ids) < currentId) {
+      snapshots.ids.push(currentId);
+      snapshots.values.push(currentValue);
+    }
+  }
+
+  function _lastSnapshotId(
+    uint256[] storage ids
+  ) private view returns (uint256) {
+    if (ids.length == 0) {
+      return 0;
+    } else {
+      return ids[ids.length - 1];
+    }
+  }
+
+  uint256[46] private __gap;
+}
+
+abstract contract PausableUpgradeable is Initializable, ContextUpgradeable {
+    
+    event Paused(address account);
+
+    
+    event Unpaused(address account);
+
+    bool private _paused;
+
+    
+    function __Pausable_init() internal onlyInitializing {
+        __Pausable_init_unchained();
+    }
+
+    function __Pausable_init_unchained() internal onlyInitializing {
+        _paused = false;
+    }
+
+    
+    modifier whenNotPaused() {
+        _requireNotPaused();
+        _;
+    }
+
+    
+    modifier whenPaused() {
+        _requirePaused();
+        _;
+    }
+
+    
+    function paused() public view virtual returns (bool) {
+        return _paused;
+    }
+
+    
+    function _requireNotPaused() internal view virtual {
+        require(!paused(), "Pausable: paused");
+    }
+
+    
+    function _requirePaused() internal view virtual {
+        require(paused(), "Pausable: not paused");
+    }
+
+    
+    function _pause() internal virtual whenNotPaused {
+        _paused = true;
+        emit Paused(_msgSender());
+    }
+
+    
+    function _unpause() internal virtual whenPaused {
+        _paused = false;
+        emit Unpaused(_msgSender());
+    }
+
+    
+    uint256[49] private __gap;
+}
+
+abstract contract ERC20PausableUpgradeable is
+  Initializable,
+  ERC20Upgradeable,
+  PausableUpgradeable {
+  function __ERC20Pausable_init() internal initializer {
+    __Context_init_unchained();
+    __Pausable_init_unchained();
+    __ERC20Pausable_init_unchained();
+  }
+
+  function __ERC20Pausable_init_unchained() internal initializer {}
+
+  
+  function _beforeTokenTransfer(
+    address from,
+    address to,
+    uint256 amount
+  ) internal virtual override {
+    super._beforeTokenTransfer(from, to, amount);
+
+    require(!paused(), "ERC20Pausable: token transfer while paused");
+  }
+
+  uint256[50] private __gap;
+}
+
+abstract contract OwnableUpgradeable is Initializable, ContextUpgradeable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    
+    function __Ownable_init() internal onlyInitializing {
+        __Ownable_init_unchained();
+    }
+
+    function __Ownable_init_unchained() internal onlyInitializing {
+        _transferOwnership(_msgSender());
+    }
+
+    
+    modifier onlyOwner() {
+        _checkOwner();
+        _;
+    }
+
+    
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    
+    function _checkOwner() internal view virtual {
+        require(owner() == _msgSender(), "Ownable: caller is not the owner");
+    }
+
+    
+    function renounceOwnership() public virtual onlyOwner {
+        _transferOwnership(address(0));
+    }
+
+    
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        _transferOwnership(newOwner);
+    }
+
+    
+    function _transferOwnership(address newOwner) internal virtual {
+        address oldOwner = _owner;
+        _owner = newOwner;
+        emit OwnershipTransferred(oldOwner, newOwner);
+    }
+
+    
+    uint256[49] private __gap;
+}
+
+library console {
+	address constant CONSOLE_ADDRESS = address(0x000000000000000000636F6e736F6c652e6c6f67);
+
+	function _sendLogPayload(bytes memory payload) private view {
+		uint256 payloadLength = payload.length;
+		address consoleAddress = CONSOLE_ADDRESS;
+		assembly {
+			let payloadStart := add(payload, 32)
+			let r := staticcall(gas(), consoleAddress, payloadStart, payloadLength, 0, 0)
+		}
+	}
+
+	function log() internal view {
+		_sendLogPayload(abi.encodeWithSignature("log()"));
+	}
+
+	function logInt(int256 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(int256)", p0));
+	}
+
+	function logUint(uint256 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256)", p0));
+	}
+
+	function logString(string memory p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string)", p0));
+	}
+
+	function logBool(bool p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool)", p0));
+	}
+
+	function logAddress(address p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address)", p0));
+	}
+
+	function logBytes(bytes memory p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes)", p0));
+	}
+
+	function logBytes1(bytes1 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes1)", p0));
+	}
+
+	function logBytes2(bytes2 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes2)", p0));
+	}
+
+	function logBytes3(bytes3 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes3)", p0));
+	}
+
+	function logBytes4(bytes4 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes4)", p0));
+	}
+
+	function logBytes5(bytes5 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes5)", p0));
+	}
+
+	function logBytes6(bytes6 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes6)", p0));
+	}
+
+	function logBytes7(bytes7 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes7)", p0));
+	}
+
+	function logBytes8(bytes8 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes8)", p0));
+	}
+
+	function logBytes9(bytes9 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes9)", p0));
+	}
+
+	function logBytes10(bytes10 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes10)", p0));
+	}
+
+	function logBytes11(bytes11 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes11)", p0));
+	}
+
+	function logBytes12(bytes12 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes12)", p0));
+	}
+
+	function logBytes13(bytes13 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes13)", p0));
+	}
+
+	function logBytes14(bytes14 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes14)", p0));
+	}
+
+	function logBytes15(bytes15 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes15)", p0));
+	}
+
+	function logBytes16(bytes16 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes16)", p0));
+	}
+
+	function logBytes17(bytes17 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes17)", p0));
+	}
+
+	function logBytes18(bytes18 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes18)", p0));
+	}
+
+	function logBytes19(bytes19 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes19)", p0));
+	}
+
+	function logBytes20(bytes20 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes20)", p0));
+	}
+
+	function logBytes21(bytes21 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes21)", p0));
+	}
+
+	function logBytes22(bytes22 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes22)", p0));
+	}
+
+	function logBytes23(bytes23 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes23)", p0));
+	}
+
+	function logBytes24(bytes24 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes24)", p0));
+	}
+
+	function logBytes25(bytes25 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes25)", p0));
+	}
+
+	function logBytes26(bytes26 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes26)", p0));
+	}
+
+	function logBytes27(bytes27 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes27)", p0));
+	}
+
+	function logBytes28(bytes28 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes28)", p0));
+	}
+
+	function logBytes29(bytes29 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes29)", p0));
+	}
+
+	function logBytes30(bytes30 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes30)", p0));
+	}
+
+	function logBytes31(bytes31 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes31)", p0));
+	}
+
+	function logBytes32(bytes32 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bytes32)", p0));
+	}
+
+	function log(uint256 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256)", p0));
+	}
+
+	function log(string memory p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string)", p0));
+	}
+
+	function log(bool p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool)", p0));
+	}
+
+	function log(address p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address)", p0));
+	}
+
+	function log(uint256 p0, uint256 p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256)", p0, p1));
+	}
+
+	function log(uint256 p0, string memory p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string)", p0, p1));
+	}
+
+	function log(uint256 p0, bool p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool)", p0, p1));
+	}
+
+	function log(uint256 p0, address p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address)", p0, p1));
+	}
+
+	function log(string memory p0, uint256 p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256)", p0, p1));
+	}
+
+	function log(string memory p0, string memory p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string)", p0, p1));
+	}
+
+	function log(string memory p0, bool p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool)", p0, p1));
+	}
+
+	function log(string memory p0, address p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address)", p0, p1));
+	}
+
+	function log(bool p0, uint256 p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256)", p0, p1));
+	}
+
+	function log(bool p0, string memory p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string)", p0, p1));
+	}
+
+	function log(bool p0, bool p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool)", p0, p1));
+	}
+
+	function log(bool p0, address p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address)", p0, p1));
+	}
+
+	function log(address p0, uint256 p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256)", p0, p1));
+	}
+
+	function log(address p0, string memory p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string)", p0, p1));
+	}
+
+	function log(address p0, bool p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool)", p0, p1));
+	}
+
+	function log(address p0, address p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address)", p0, p1));
+	}
+
+	function log(uint256 p0, uint256 p1, uint256 p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256)", p0, p1, p2));
+	}
+
+	function log(uint256 p0, uint256 p1, string memory p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string)", p0, p1, p2));
+	}
+
+	function log(uint256 p0, uint256 p1, bool p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool)", p0, p1, p2));
+	}
+
+	function log(uint256 p0, uint256 p1, address p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address)", p0, p1, p2));
+	}
+
+	function log(uint256 p0, string memory p1, uint256 p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256)", p0, p1, p2));
+	}
+
+	function log(uint256 p0, string memory p1, string memory p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,string)", p0, p1, p2));
+	}
+
+	function log(uint256 p0, string memory p1, bool p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool)", p0, p1, p2));
+	}
+
+	function log(uint256 p0, string memory p1, address p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,address)", p0, p1, p2));
+	}
+
+	function log(uint256 p0, bool p1, uint256 p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256)", p0, p1, p2));
+	}
+
+	function log(uint256 p0, bool p1, string memory p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string)", p0, p1, p2));
+	}
+
+	function log(uint256 p0, bool p1, bool p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool)", p0, p1, p2));
+	}
+
+	function log(uint256 p0, bool p1, address p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address)", p0, p1, p2));
+	}
+
+	function log(uint256 p0, address p1, uint256 p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256)", p0, p1, p2));
+	}
+
+	function log(uint256 p0, address p1, string memory p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,string)", p0, p1, p2));
+	}
+
+	function log(uint256 p0, address p1, bool p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool)", p0, p1, p2));
+	}
+
+	function log(uint256 p0, address p1, address p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,address)", p0, p1, p2));
+	}
+
+	function log(string memory p0, uint256 p1, uint256 p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256)", p0, p1, p2));
+	}
+
+	function log(string memory p0, uint256 p1, string memory p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,string)", p0, p1, p2));
+	}
+
+	function log(string memory p0, uint256 p1, bool p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool)", p0, p1, p2));
+	}
+
+	function log(string memory p0, uint256 p1, address p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,address)", p0, p1, p2));
+	}
+
+	function log(string memory p0, string memory p1, uint256 p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,uint256)", p0, p1, p2));
+	}
+
+	function log(string memory p0, string memory p1, string memory p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,string)", p0, p1, p2));
+	}
+
+	function log(string memory p0, string memory p1, bool p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,bool)", p0, p1, p2));
+	}
+
+	function log(string memory p0, string memory p1, address p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,address)", p0, p1, p2));
+	}
+
+	function log(string memory p0, bool p1, uint256 p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256)", p0, p1, p2));
+	}
+
+	function log(string memory p0, bool p1, string memory p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,string)", p0, p1, p2));
+	}
+
+	function log(string memory p0, bool p1, bool p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,bool)", p0, p1, p2));
+	}
+
+	function log(string memory p0, bool p1, address p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,address)", p0, p1, p2));
+	}
+
+	function log(string memory p0, address p1, uint256 p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,uint256)", p0, p1, p2));
+	}
+
+	function log(string memory p0, address p1, string memory p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,string)", p0, p1, p2));
+	}
+
+	function log(string memory p0, address p1, bool p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,bool)", p0, p1, p2));
+	}
+
+	function log(string memory p0, address p1, address p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,address)", p0, p1, p2));
+	}
+
+	function log(bool p0, uint256 p1, uint256 p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256)", p0, p1, p2));
+	}
+
+	function log(bool p0, uint256 p1, string memory p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string)", p0, p1, p2));
+	}
+
+	function log(bool p0, uint256 p1, bool p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool)", p0, p1, p2));
+	}
+
+	function log(bool p0, uint256 p1, address p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address)", p0, p1, p2));
+	}
+
+	function log(bool p0, string memory p1, uint256 p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256)", p0, p1, p2));
+	}
+
+	function log(bool p0, string memory p1, string memory p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,string)", p0, p1, p2));
+	}
+
+	function log(bool p0, string memory p1, bool p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,bool)", p0, p1, p2));
+	}
+
+	function log(bool p0, string memory p1, address p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,address)", p0, p1, p2));
+	}
+
+	function log(bool p0, bool p1, uint256 p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256)", p0, p1, p2));
+	}
+
+	function log(bool p0, bool p1, string memory p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,string)", p0, p1, p2));
+	}
+
+	function log(bool p0, bool p1, bool p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool)", p0, p1, p2));
+	}
+
+	function log(bool p0, bool p1, address p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,address)", p0, p1, p2));
+	}
+
+	function log(bool p0, address p1, uint256 p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256)", p0, p1, p2));
+	}
+
+	function log(bool p0, address p1, string memory p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,string)", p0, p1, p2));
+	}
+
+	function log(bool p0, address p1, bool p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,bool)", p0, p1, p2));
+	}
+
+	function log(bool p0, address p1, address p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,address)", p0, p1, p2));
+	}
+
+	function log(address p0, uint256 p1, uint256 p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256)", p0, p1, p2));
+	}
+
+	function log(address p0, uint256 p1, string memory p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,string)", p0, p1, p2));
+	}
+
+	function log(address p0, uint256 p1, bool p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool)", p0, p1, p2));
+	}
+
+	function log(address p0, uint256 p1, address p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,address)", p0, p1, p2));
+	}
+
+	function log(address p0, string memory p1, uint256 p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,uint256)", p0, p1, p2));
+	}
+
+	function log(address p0, string memory p1, string memory p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,string)", p0, p1, p2));
+	}
+
+	function log(address p0, string memory p1, bool p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,bool)", p0, p1, p2));
+	}
+
+	function log(address p0, string memory p1, address p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,address)", p0, p1, p2));
+	}
+
+	function log(address p0, bool p1, uint256 p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256)", p0, p1, p2));
+	}
+
+	function log(address p0, bool p1, string memory p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,string)", p0, p1, p2));
+	}
+
+	function log(address p0, bool p1, bool p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,bool)", p0, p1, p2));
+	}
+
+	function log(address p0, bool p1, address p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,address)", p0, p1, p2));
+	}
+
+	function log(address p0, address p1, uint256 p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,uint256)", p0, p1, p2));
+	}
+
+	function log(address p0, address p1, string memory p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,string)", p0, p1, p2));
+	}
+
+	function log(address p0, address p1, bool p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,bool)", p0, p1, p2));
+	}
+
+	function log(address p0, address p1, address p2) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,address)", p0, p1, p2));
+	}
+
+	function log(uint256 p0, uint256 p1, uint256 p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, uint256 p1, uint256 p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256,string)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, uint256 p1, uint256 p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256,bool)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, uint256 p1, uint256 p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256,address)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, uint256 p1, string memory p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, uint256 p1, string memory p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string,string)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, uint256 p1, string memory p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string,bool)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, uint256 p1, string memory p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string,address)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, uint256 p1, bool p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, uint256 p1, bool p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool,string)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, uint256 p1, bool p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool,bool)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, uint256 p1, bool p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool,address)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, uint256 p1, address p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, uint256 p1, address p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address,string)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, uint256 p1, address p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address,bool)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, uint256 p1, address p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address,address)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, string memory p1, uint256 p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, string memory p1, uint256 p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256,string)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, string memory p1, uint256 p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256,bool)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, string memory p1, uint256 p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256,address)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, string memory p1, string memory p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,string,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, string memory p1, string memory p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,string,string)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, string memory p1, string memory p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,string,bool)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, string memory p1, string memory p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,string,address)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, string memory p1, bool p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, string memory p1, bool p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool,string)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, string memory p1, bool p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool,bool)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, string memory p1, bool p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool,address)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, string memory p1, address p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,address,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, string memory p1, address p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,address,string)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, string memory p1, address p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,address,bool)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, string memory p1, address p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,string,address,address)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, bool p1, uint256 p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, bool p1, uint256 p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256,string)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, bool p1, uint256 p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256,bool)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, bool p1, uint256 p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256,address)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, bool p1, string memory p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, bool p1, string memory p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string,string)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, bool p1, string memory p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string,bool)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, bool p1, string memory p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string,address)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, bool p1, bool p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, bool p1, bool p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool,string)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, bool p1, bool p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool,bool)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, bool p1, bool p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool,address)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, bool p1, address p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, bool p1, address p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address,string)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, bool p1, address p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address,bool)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, bool p1, address p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address,address)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, address p1, uint256 p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, address p1, uint256 p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256,string)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, address p1, uint256 p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256,bool)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, address p1, uint256 p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256,address)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, address p1, string memory p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,string,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, address p1, string memory p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,string,string)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, address p1, string memory p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,string,bool)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, address p1, string memory p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,string,address)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, address p1, bool p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, address p1, bool p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool,string)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, address p1, bool p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool,bool)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, address p1, bool p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool,address)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, address p1, address p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,address,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, address p1, address p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,address,string)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, address p1, address p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,address,bool)", p0, p1, p2, p3));
+	}
+
+	function log(uint256 p0, address p1, address p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint256,address,address,address)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, uint256 p1, uint256 p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, uint256 p1, uint256 p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256,string)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, uint256 p1, uint256 p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256,bool)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, uint256 p1, uint256 p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256,address)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, uint256 p1, string memory p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,string,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, uint256 p1, string memory p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,string,string)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, uint256 p1, string memory p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,string,bool)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, uint256 p1, string memory p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,string,address)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, uint256 p1, bool p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, uint256 p1, bool p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool,string)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, uint256 p1, bool p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool,bool)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, uint256 p1, bool p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool,address)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, uint256 p1, address p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,address,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, uint256 p1, address p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,address,string)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, uint256 p1, address p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,address,bool)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, uint256 p1, address p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint256,address,address)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, string memory p1, uint256 p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,uint256,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, string memory p1, uint256 p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,uint256,string)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, string memory p1, uint256 p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,uint256,bool)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, string memory p1, uint256 p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,uint256,address)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, string memory p1, string memory p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,string,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, string memory p1, string memory p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,string,string)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, string memory p1, string memory p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,string,bool)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, string memory p1, string memory p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,string,address)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, string memory p1, bool p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,bool,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, string memory p1, bool p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,bool,string)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, string memory p1, bool p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,bool,bool)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, string memory p1, bool p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,bool,address)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, string memory p1, address p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,address,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, string memory p1, address p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,address,string)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, string memory p1, address p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,address,bool)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, string memory p1, address p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string,address,address)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, bool p1, uint256 p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, bool p1, uint256 p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256,string)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, bool p1, uint256 p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256,bool)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, bool p1, uint256 p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256,address)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, bool p1, string memory p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,string,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, bool p1, string memory p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,string,string)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, bool p1, string memory p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,string,bool)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, bool p1, string memory p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,string,address)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, bool p1, bool p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, bool p1, bool p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,string)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, bool p1, bool p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,bool)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, bool p1, bool p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,address)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, bool p1, address p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,address,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, bool p1, address p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,address,string)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, bool p1, address p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,address,bool)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, bool p1, address p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool,address,address)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, address p1, uint256 p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,uint256,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, address p1, uint256 p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,uint256,string)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, address p1, uint256 p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,uint256,bool)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, address p1, uint256 p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,uint256,address)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, address p1, string memory p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,string,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, address p1, string memory p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,string,string)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, address p1, string memory p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,string,bool)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, address p1, string memory p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,string,address)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, address p1, bool p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,bool,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, address p1, bool p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,bool,string)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, address p1, bool p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,bool,bool)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, address p1, bool p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,bool,address)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, address p1, address p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,address,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, address p1, address p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,address,string)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, address p1, address p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,address,bool)", p0, p1, p2, p3));
+	}
+
+	function log(string memory p0, address p1, address p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address,address,address)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, uint256 p1, uint256 p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, uint256 p1, uint256 p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256,string)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, uint256 p1, uint256 p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256,bool)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, uint256 p1, uint256 p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256,address)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, uint256 p1, string memory p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, uint256 p1, string memory p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string,string)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, uint256 p1, string memory p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string,bool)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, uint256 p1, string memory p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string,address)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, uint256 p1, bool p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, uint256 p1, bool p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool,string)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, uint256 p1, bool p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool,bool)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, uint256 p1, bool p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool,address)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, uint256 p1, address p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, uint256 p1, address p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address,string)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, uint256 p1, address p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address,bool)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, uint256 p1, address p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address,address)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, string memory p1, uint256 p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, string memory p1, uint256 p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256,string)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, string memory p1, uint256 p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256,bool)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, string memory p1, uint256 p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256,address)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, string memory p1, string memory p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,string,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, string memory p1, string memory p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,string,string)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, string memory p1, string memory p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,string,bool)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, string memory p1, string memory p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,string,address)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, string memory p1, bool p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, string memory p1, bool p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,string)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, string memory p1, bool p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,bool)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, string memory p1, bool p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,address)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, string memory p1, address p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,address,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, string memory p1, address p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,address,string)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, string memory p1, address p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,address,bool)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, string memory p1, address p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,string,address,address)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, bool p1, uint256 p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, bool p1, uint256 p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256,string)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, bool p1, uint256 p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256,bool)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, bool p1, uint256 p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256,address)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, bool p1, string memory p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, bool p1, string memory p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,string)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, bool p1, string memory p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,bool)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, bool p1, string memory p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,address)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, bool p1, bool p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, bool p1, bool p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,string)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, bool p1, bool p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,bool)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, bool p1, bool p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,address)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, bool p1, address p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, bool p1, address p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,string)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, bool p1, address p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,bool)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, bool p1, address p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,address)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, address p1, uint256 p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, address p1, uint256 p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256,string)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, address p1, uint256 p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256,bool)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, address p1, uint256 p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256,address)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, address p1, string memory p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,string,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, address p1, string memory p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,string,string)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, address p1, string memory p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,string,bool)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, address p1, string memory p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,string,address)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, address p1, bool p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, address p1, bool p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,string)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, address p1, bool p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,bool)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, address p1, bool p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,address)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, address p1, address p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,address,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, address p1, address p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,address,string)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, address p1, address p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,address,bool)", p0, p1, p2, p3));
+	}
+
+	function log(bool p0, address p1, address p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool,address,address,address)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, uint256 p1, uint256 p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, uint256 p1, uint256 p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256,string)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, uint256 p1, uint256 p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256,bool)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, uint256 p1, uint256 p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256,address)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, uint256 p1, string memory p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,string,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, uint256 p1, string memory p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,string,string)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, uint256 p1, string memory p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,string,bool)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, uint256 p1, string memory p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,string,address)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, uint256 p1, bool p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, uint256 p1, bool p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool,string)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, uint256 p1, bool p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool,bool)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, uint256 p1, bool p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool,address)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, uint256 p1, address p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,address,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, uint256 p1, address p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,address,string)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, uint256 p1, address p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,address,bool)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, uint256 p1, address p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,uint256,address,address)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, string memory p1, uint256 p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,uint256,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, string memory p1, uint256 p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,uint256,string)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, string memory p1, uint256 p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,uint256,bool)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, string memory p1, uint256 p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,uint256,address)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, string memory p1, string memory p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,string,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, string memory p1, string memory p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,string,string)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, string memory p1, string memory p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,string,bool)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, string memory p1, string memory p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,string,address)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, string memory p1, bool p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,bool,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, string memory p1, bool p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,bool,string)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, string memory p1, bool p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,bool,bool)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, string memory p1, bool p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,bool,address)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, string memory p1, address p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,address,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, string memory p1, address p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,address,string)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, string memory p1, address p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,address,bool)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, string memory p1, address p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,string,address,address)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, bool p1, uint256 p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, bool p1, uint256 p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256,string)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, bool p1, uint256 p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256,bool)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, bool p1, uint256 p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256,address)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, bool p1, string memory p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,string,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, bool p1, string memory p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,string,string)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, bool p1, string memory p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,string,bool)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, bool p1, string memory p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,string,address)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, bool p1, bool p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, bool p1, bool p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,string)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, bool p1, bool p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,bool)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, bool p1, bool p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,address)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, bool p1, address p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,address,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, bool p1, address p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,address,string)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, bool p1, address p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,address,bool)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, bool p1, address p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,bool,address,address)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, address p1, uint256 p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,uint256,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, address p1, uint256 p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,uint256,string)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, address p1, uint256 p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,uint256,bool)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, address p1, uint256 p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,uint256,address)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, address p1, string memory p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,string,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, address p1, string memory p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,string,string)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, address p1, string memory p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,string,bool)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, address p1, string memory p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,string,address)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, address p1, bool p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,bool,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, address p1, bool p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,bool,string)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, address p1, bool p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,bool,bool)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, address p1, bool p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,bool,address)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, address p1, address p2, uint256 p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,address,uint256)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, address p1, address p2, string memory p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,address,string)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, address p1, address p2, bool p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,address,bool)", p0, p1, p2, p3));
+	}
+
+	function log(address p0, address p1, address p2, address p3) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address,address,address,address)", p0, p1, p2, p3));
+	}
+
+}
+
+contract BlocjerkTokenV4WithVersion is
+  OwnableUpgradeable,
+  ERC20Upgradeable,
+  ERC20PausableUpgradeable,
+  ERC20SnapshotUpgradeable {
+  event AuthorizedSnapshotter(address account);
+  event DeauthorizedSnapshotter(address account);
+  event BuySellTaxRate(uint256 buyTaxRate, uint256 sellTaxRate);
+
+  
+  enum TransactionType {
+    REGULAR,
+    TAX,
+    SELL,
+    BUY
+  }
+
+  
+  mapping(address => bool) authorizedToSnapshot;
+
+  
+  
+  
+  uint256 public buyTaxRate;
+  uint256 public sellTaxRate;
+
+  
+  
+  
+  
+  mapping(address => bool) public poolsToTax;
+
+  address public taxTo;
+
+  
+  uint256 internal accumulatedTax;
+
+  uint256 public version;
+
+  function initialize(
+    string memory name,
+    string memory symbol
+  ) public initializer {
+    __Ownable_init();
+    __ERC20_init(name, symbol);
+    __ERC20Snapshot_init();
+    __ERC20Pausable_init();
+  }
+
+  
+  function initializeImplementation() public initializer {
+    __Ownable_init();
+    _pause();
+  }
+
+  
+  function mint(address account, uint256 amount) external onlyOwner {
+    _mint(account, amount);
+  }
+
+  
+  function burn(address account, uint256 amount) external onlyOwner {
+    _burn(account, amount);
+  }
+
+  
+  function pause() external onlyOwner {
+    _pause();
+  }
+
+  
+  function unpause() external onlyOwner {
+    _unpause();
+  }
+
+  
+  function snapshot() external returns (uint256) {
+    require(
+      authorizedToSnapshot[_msgSender()] || _msgSender() == owner(),
+      "zDAOToken: Not authorized to snapshot"
+    );
+    return _snapshot();
+  }
+
+  
+  function authorizeSnapshotter(address account) external onlyOwner {
+    require(
+      !authorizedToSnapshot[account],
+      "zDAOToken: Account already authorized"
+    );
+
+    authorizedToSnapshot[account] = true;
+    emit AuthorizedSnapshotter(account);
+  }
+
+  
+  function deauthorizeSnapshotter(address account) external onlyOwner {
+    require(authorizedToSnapshot[account], "zDAOToken: Account not authorized");
+
+    authorizedToSnapshot[account] = false;
+    emit DeauthorizedSnapshotter(account);
+  }
+
+  
+  function transferBulk(
+    address[] calldata recipients,
+    uint256[] calldata amounts
+  ) external onlyOwner returns (bool) {
+    require(!paused(), "ERC20Pausable: token transfer while paused");
+    require(recipients.length == amounts.length, "Invalid arguments length");
+
+    address sender = _msgSender();
+
+    uint256 length = recipients.length;
+    uint256 total = 0;
+    for (uint256 i = 0; i < length; ++i) {
+      total += amounts[i];
+    }
+    require(
+      _balances[sender] >= total,
+      "ERC20: transfer amount exceeds balance"
+    );
+
+    _balances[sender] -= total;
+    _updateAccountSnapshot(sender);
+
+    for (uint256 i = 0; i < length; ++i) {
+      address recipient = recipients[i];
+      require(recipient != address(0), "ERC20: transfer to the zero address");
+
+      
+      
+
+      _balances[recipient] += amounts[i];
+
+      _updateAccountSnapshot(recipient);
+
+      emit Transfer(sender, recipient, amounts[i]);
+    }
+
+    return true;
+  }
+
+  
+  function transferFromBulk(
+    address sender,
+    address[] calldata recipients,
+    uint256[] calldata amounts
+  ) external onlyOwner returns (bool) {
+    require(!paused(), "ERC20Pausable: token transfer while paused");
+    require(recipients.length == amounts.length, "Invalid arguments length");
+
+    uint256 length = recipients.length;
+    uint256 total = 0;
+    for (uint256 i = 0; i < length; ++i) {
+      total += amounts[i];
+    }
+    require(
+      _balances[sender] >= total,
+      "ERC20: transfer amount exceeds balance"
+    );
+
+    
+    uint256 currentAllowance = _allowances[sender][_msgSender()];
+    require(
+      currentAllowance >= total,
+      "ERC20: transfer total exceeds allowance"
+    );
+    _approve(sender, _msgSender(), currentAllowance - total);
+
+    _balances[sender] -= total;
+    _updateAccountSnapshot(sender);
+
+    for (uint256 i = 0; i < length; ++i) {
+      address recipient = recipients[i];
+      require(recipient != address(0), "ERC20: transfer to the zero address");
+
+      
+      
+
+      _balances[recipient] += amounts[i];
+
+      _updateAccountSnapshot(recipient);
+
+      emit Transfer(sender, recipient, amounts[i]);
+    }
+
+    return true;
+  }
+
+  function burnBulk(
+    address[] calldata accounts,
+    uint256[] calldata amounts
+  ) external onlyOwner {
+    require(accounts.length == amounts.length, "Invalid argument");
+    uint256 len = accounts.length;
+    for (uint256 i = 0; i < len; ++i) {
+      _burn(accounts[i], amounts[i]);
+    }
+  }
+
+  
+  function setBuySellTaxRate(
+    uint256 buyTaxRate_,
+    uint256 sellTaxRate_
+  ) external onlyOwner {
+    require(buyTaxRate != buyTaxRate_ || sellTaxRate != sellTaxRate_);
+
+    buyTaxRate = buyTaxRate_;
+    sellTaxRate = sellTaxRate_;
+
+    emit BuySellTaxRate(buyTaxRate_, sellTaxRate_);
+  }
+
+  
+  function setTaxTo(address taxTo_) external onlyOwner {
+    require(taxTo != taxTo_);
+
+    taxTo = taxTo_;
+  }
+
+  function addPoolToTax(address pool_) external onlyOwner {
+    require(pool_ != address(0));
+
+    poolsToTax[pool_] = true;
+  }
+
+  function removePoolToTax(address pool_) external onlyOwner {
+    require(pool_ != address(0));
+
+    poolsToTax[pool_] = false;
+  }
+
+  function _beforeTokenTransfer(
+    address from,
+    address to,
+    uint256 amount
+  )
+    internal
+    virtual
+    override(
+      ERC20PausableUpgradeable,
+      ERC20SnapshotUpgradeable,
+      ERC20Upgradeable
+    )
+  {
+    bool alreadyPaused = paused();
+    if (to == address(0)) {
+      if (alreadyPaused) {
+        _unpause();
+      }
+    }
+    super._beforeTokenTransfer(from, to, amount);
+    if (to == address(0)) {
+      if (alreadyPaused) {
+        _pause();
+      }
+    }
+  }
+
+  function _transfer(
+    address sender,
+    address recipient,
+    uint256 amount
+  ) internal virtual override {
+    uint256 taxAmount = _takeFee(sender, recipient, amount);
+
+    
+    super._transfer(sender, recipient, amount - taxAmount);
+
+    
+    if (taxAmount > 0) {
+      super._transfer(sender, address(this), taxAmount);
+      accumulatedTax += taxAmount;
+    }
+  }
+
+  function _takeFee(
+    address sender,
+    address recipient,
+    uint256 amount
+  ) internal virtual returns (uint256) {
+    
+    if (_getTransactionType(sender, recipient) == TransactionType.SELL) {
+      
+      return (amount * sellTaxRate) / 10000;
+    } else if (_getTransactionType(sender, recipient) == TransactionType.BUY) {
+      
+      return (amount * buyTaxRate) / 10000;
+    }
+    return 0;
+  }
+
+  
+  function _getTransactionType(
+    address from,
+    address to
+  ) internal view returns (TransactionType) {
+    if (poolsToTax[from] && !poolsToTax[to]) {
+      
+      return TransactionType.BUY;
+    } else if (!poolsToTax[from] && poolsToTax[to]) {
+      
+      return TransactionType.SELL;
+    } else if (from == address(this) || to == address(this)) {
+      return TransactionType.TAX;
+    }
+    return TransactionType.REGULAR;
+  }
+}
+
+interface IUniswapV2Factory {
+    event PairCreated(address indexed token0, address indexed token1, address pair, uint);
+
+    function feeTo() external view returns (address);
+    function feeToSetter() external view returns (address);
+
+    function getPair(address tokenA, address tokenB) external view returns (address pair);
+    function allPairs(uint) external view returns (address pair);
+    function allPairsLength() external view returns (uint);
+
+    function createPair(address tokenA, address tokenB) external returns (address pair);
+
+    function setFeeTo(address) external;
+    function setFeeToSetter(address) external;
+}
+
+interface IUniswapV2Router01 {
+    function factory() external pure returns (address);
+    function WETH() external pure returns (address);
+
+    function addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint amountADesired,
+        uint amountBDesired,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountA, uint amountB, uint liquidity);
+    function addLiquidityETH(
+        address token,
+        uint amountTokenDesired,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    ) external payable returns (uint amountToken, uint amountETH, uint liquidity);
+    function removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint liquidity,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountA, uint amountB);
+    function removeLiquidityETH(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountToken, uint amountETH);
+    function removeLiquidityWithPermit(
+        address tokenA,
+        address tokenB,
+        uint liquidity,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline,
+        bool approveMax, uint8 v, bytes32 r, bytes32 s
+    ) external returns (uint amountA, uint amountB);
+    function removeLiquidityETHWithPermit(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline,
+        bool approveMax, uint8 v, bytes32 r, bytes32 s
+    ) external returns (uint amountToken, uint amountETH);
+    function swapExactTokensForTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+    function swapTokensForExactTokens(
+        uint amountOut,
+        uint amountInMax,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+    function swapExactETHForTokens(uint amountOutMin, address[] calldata path, address to, uint deadline)
+        external
+        payable
+        returns (uint[] memory amounts);
+    function swapTokensForExactETH(uint amountOut, uint amountInMax, address[] calldata path, address to, uint deadline)
+        external
+        returns (uint[] memory amounts);
+    function swapExactTokensForETH(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline)
+        external
+        returns (uint[] memory amounts);
+    function swapETHForExactTokens(uint amountOut, address[] calldata path, address to, uint deadline)
+        external
+        payable
+        returns (uint[] memory amounts);
+
+    function quote(uint amountA, uint reserveA, uint reserveB) external pure returns (uint amountB);
+    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut) external pure returns (uint amountOut);
+    function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut) external pure returns (uint amountIn);
+    function getAmountsOut(uint amountIn, address[] calldata path) external view returns (uint[] memory amounts);
+    function getAmountsIn(uint amountOut, address[] calldata path) external view returns (uint[] memory amounts);
+}
+
+interface IUniswapV2Router02 is IUniswapV2Router01 {
+    function removeLiquidityETHSupportingFeeOnTransferTokens(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountETH);
+    function removeLiquidityETHWithPermitSupportingFeeOnTransferTokens(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline,
+        bool approveMax, uint8 v, bytes32 r, bytes32 s
+    ) external returns (uint amountETH);
+
+    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external;
+    function swapExactETHForTokensSupportingFeeOnTransferTokens(
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external payable;
+    function swapExactTokensForETHSupportingFeeOnTransferTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external;
+}
+
+library SafeMathUpgradeable {
+    
+    function tryAdd(uint256 a, uint256 b) internal pure returns (bool, uint256) {
+        unchecked {
+            uint256 c = a + b;
+            if (c < a) return (false, 0);
+            return (true, c);
+        }
+    }
+
+    
+    function trySub(uint256 a, uint256 b) internal pure returns (bool, uint256) {
+        unchecked {
+            if (b > a) return (false, 0);
+            return (true, a - b);
+        }
+    }
+
+    
+    function tryMul(uint256 a, uint256 b) internal pure returns (bool, uint256) {
+        unchecked {
+            
+            
+            
+            if (a == 0) return (true, 0);
+            uint256 c = a * b;
+            if (c / a != b) return (false, 0);
+            return (true, c);
+        }
+    }
+
+    
+    function tryDiv(uint256 a, uint256 b) internal pure returns (bool, uint256) {
+        unchecked {
+            if (b == 0) return (false, 0);
+            return (true, a / b);
+        }
+    }
+
+    
+    function tryMod(uint256 a, uint256 b) internal pure returns (bool, uint256) {
+        unchecked {
+            if (b == 0) return (false, 0);
+            return (true, a % b);
+        }
+    }
+
+    
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a + b;
+    }
+
+    
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a - b;
+    }
+
+    
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a * b;
+    }
+
+    
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a / b;
+    }
+
+    
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a % b;
+    }
+
+    
+    function sub(
+        uint256 a,
+        uint256 b,
+        string memory errorMessage
+    ) internal pure returns (uint256) {
+        unchecked {
+            require(b <= a, errorMessage);
+            return a - b;
+        }
+    }
+
+    
+    function div(
+        uint256 a,
+        uint256 b,
+        string memory errorMessage
+    ) internal pure returns (uint256) {
+        unchecked {
+            require(b > 0, errorMessage);
+            return a / b;
+        }
+    }
+
+    
+    function mod(
+        uint256 a,
+        uint256 b,
+        string memory errorMessage
+    ) internal pure returns (uint256) {
+        unchecked {
+            require(b > 0, errorMessage);
+            return a % b;
+        }
+    }
+}
+
+abstract contract Uniswap is OwnableUpgradeable {
+  using SafeMathUpgradeable for uint256;
+  
+  IUniswapV2Router02 internal uniswapV2Router;
+  
+  address internal uniswapV2Pair;
+  
+  address internal routerAddr;
+
+  
+  receive() external payable {}
+
+  function setRouter(address router, address pair) external onlyOwner {
+    require(router != address(0));
+    uniswapV2Router = IUniswapV2Router02(router);
+    uniswapV2Pair = pair;
+    emit RouterSet(router, pair);
+  }
+
+  
+  function swapTokensForETH(uint256 tokenAmount) internal returns (uint256) {
+    if (address(uniswapV2Router) != address(0)) {
+      uint256 initialBalance = address(this).balance;
+      
+      address[] memory path = new address[](2);
+      path[0] = address(this);
+      path[1] = uniswapV2Router.WETH();
+
+      
+      uniswapV2Router.swapExactTokensForETHSupportingFeeOnTransferTokens(
+        tokenAmount,
+        0, 
+        path,
+        address(this),
+        block.timestamp
+      );
+
+      uint256 ethReceived = address(this).balance.sub(initialBalance);
+      return ethReceived;
+    }
+    return 0;
+  }
+
+  function swapTokensByPath(
+    uint256 tokenAmountIn,
+    uint256 tokenAmountOutMin,
+    address[] memory path,
+    address to
+  ) internal {
+    if (address(uniswapV2Router) != address(0)) {
+      
+      uniswapV2Router.swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        tokenAmountIn,
+        tokenAmountOutMin,
+        path,
+        to,
+        block.timestamp
+      );
+    }
+  }
+
+  
+  event RouterSet(address indexed router, address indexed pair);
+
+  
+  modifier pcsInitialized() {
+    require(routerAddr != address(0), "Router address has not been set!");
+    _;
+  }
+}
+
+contract BlocjerkTokenV5 is BlocjerkTokenV4WithVersion, Uniswap {
+  event SoldTax(uint256 tokensSold, uint256 ethReceived);
+  event SetMinTaxForSell(uint256 minTaxForSell);
+
+  
+  
+  uint256 public minTaxForSell;
+
+  
+  address public USDT;
+
+  bool internal inTriggerProcess;
+  modifier lockTheProcess() {
+    inTriggerProcess = true;
+    _;
+    inTriggerProcess = false;
+  }
+
+  
+  function upgradeToV5() external {
+    require(version < 5, "DeHubToken: Already upgraded to version 5");
+    version = 5;
+    console.log("v", version);
+  }
+
+  function setUSDT(address USDT_) external onlyOwner {
+    USDT = USDT_;
+  }
+
+  function setMinTaxForSell(uint256 minTaxForSell_) external onlyOwner {
+    require(minTaxForSell != minTaxForSell_);
+    minTaxForSell = minTaxForSell_;
+    emit SetMinTaxForSell(minTaxForSell_);
+  }
+
+  function _beforeTokenTransfer(
+    address from,
+    address to,
+    uint256 amount
+  ) internal virtual override {
+    super._beforeTokenTransfer(from, to, amount);
+
+    TransactionType txType = _getTransactionType(from, to);
+    
+    
+    if (!inTriggerProcess && txType == TransactionType.REGULAR) {
+      _triggerSellTax();
+    }
+  }
+
+  function _takeFee(
+    address sender,
+    address recipient,
+    uint256 amount
+  ) internal virtual override returns (uint256) {
+    if (inTriggerProcess) {
+      return 0;
+    }
+    return super._takeFee(sender, recipient, amount);
+  }
+
+  function _canSellTax(
+    uint256 contractTokenBalance
+  ) internal view virtual returns (bool) {
+    return contractTokenBalance >= minTaxForSell && minTaxForSell > 0;
+  }
+
+  function _triggerSellTax() internal virtual {
+    uint256 contractTokenBalance = balanceOf(address(this));
+    if (_canSellTax(contractTokenBalance)) {
+      _sellTax(contractTokenBalance);
+    }
+  }
+
+  function _sellTax(uint256 tokenAmount) internal virtual lockTheProcess {
+    uint256 tokensSold;
+    uint256 ethReceived;
+
+    if (
+      taxTo != address(0) &&
+      tokenAmount > 0 &&
+      address(uniswapV2Router) != address(0)
+    ) {
+      
+      _approve(address(this), address(uniswapV2Router), tokenAmount);
+
+      ethReceived = swapTokensForETH(tokenAmount);
+      if (ethReceived > 0) {
+        tokensSold = tokenAmount;
+        payable(taxTo).transfer(ethReceived);
+      }
+    }
+    emit SoldTax(tokensSold, ethReceived);
+  }
+}
+
+interface IUniswapV3SwapCallback {
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    function uniswapV3SwapCallback(
+        int256 amount0Delta,
+        int256 amount1Delta,
+        bytes calldata data
+    ) external;
+}
+
+interface ISwapRouter is IUniswapV3SwapCallback {
+    struct ExactInputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 deadline;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    
+    
+    
+    function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut);
+
+    struct ExactInputParams {
+        bytes path;
+        address recipient;
+        uint256 deadline;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+    }
+
+    
+    
+    
+    function exactInput(ExactInputParams calldata params) external payable returns (uint256 amountOut);
+
+    struct ExactOutputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 deadline;
+        uint256 amountOut;
+        uint256 amountInMaximum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    
+    
+    
+    function exactOutputSingle(ExactOutputSingleParams calldata params) external payable returns (uint256 amountIn);
+
+    struct ExactOutputParams {
+        bytes path;
+        address recipient;
+        uint256 deadline;
+        uint256 amountOut;
+        uint256 amountInMaximum;
+    }
+
+    
+    
+    
+    function exactOutput(ExactOutputParams calldata params) external payable returns (uint256 amountIn);
+}
+
+library TransferHelper {
+    
+    
+    
+    
+    
+    
+    function safeTransferFrom(
+        address token,
+        address from,
+        address to,
+        uint256 value
+    ) internal {
+        (bool success, bytes memory data) =
+            token.call(abi.encodeWithSelector(IERC20.transferFrom.selector, from, to, value));
+        require(success && (data.length == 0 || abi.decode(data, (bool))), 'STF');
+    }
+
+    
+    
+    
+    
+    
+    function safeTransfer(
+        address token,
+        address to,
+        uint256 value
+    ) internal {
+        (bool success, bytes memory data) = token.call(abi.encodeWithSelector(IERC20.transfer.selector, to, value));
+        require(success && (data.length == 0 || abi.decode(data, (bool))), 'ST');
+    }
+
+    
+    
+    
+    
+    
+    function safeApprove(
+        address token,
+        address to,
+        uint256 value
+    ) internal {
+        (bool success, bytes memory data) = token.call(abi.encodeWithSelector(IERC20.approve.selector, to, value));
+        require(success && (data.length == 0 || abi.decode(data, (bool))), 'SA');
+    }
+
+    
+    
+    
+    
+    function safeTransferETH(address to, uint256 value) internal {
+        (bool success, ) = to.call{value: value}(new bytes(0));
+        require(success, 'STE');
+    }
+}
+
+interface IPeripheryImmutableState {
+    
+    function factory() external view returns (address);
+
+    
+    function WETH9() external view returns (address);
+}
+
+interface IUniswapRouter02 is IPeripheryImmutableState {
+  struct ExactInputSingleParams {
+    address tokenIn;
+    address tokenOut;
+    uint24 fee;
+    address recipient;
+    uint256 amountIn;
+    uint256 amountOutMinimum;
+    uint160 sqrtPriceLimitX96;
+  }
+
+  
+  
+  
+  
+  
+  function exactInputSingle(
+    ExactInputSingleParams calldata params
+  ) external payable returns (uint256 amountOut);
+
+  struct ExactInputParams {
+    bytes path;
+    address recipient;
+    uint256 amountIn;
+    uint256 amountOutMinimum;
+  }
+
+  
+  
+  
+  
+  
+  function exactInput(
+    ExactInputParams calldata params
+  ) external payable returns (uint256 amountOut);
+
+  struct ExactOutputSingleParams {
+    address tokenIn;
+    address tokenOut;
+    uint24 fee;
+    address recipient;
+    uint256 amountOut;
+    uint256 amountInMaximum;
+    uint160 sqrtPriceLimitX96;
+  }
+
+  
+  
+  
+  
+  function exactOutputSingle(
+    ExactOutputSingleParams calldata params
+  ) external payable returns (uint256 amountIn);
+
+  struct ExactOutputParams {
+    bytes path;
+    address recipient;
+    uint256 amountOut;
+    uint256 amountInMaximum;
+  }
+
+  
+  
+  
+  
+  function exactOutput(
+    ExactOutputParams calldata params
+  ) external payable returns (uint256 amountIn);
+}
+
+abstract contract UniswapV3 is OwnableUpgradeable {
+  
+  
+  
+  
+  IUniswapRouter02 internal uniswapV3Router;
+
+  function setUniswapV3Router(address router) external onlyOwner {
+    require(router != address(0));
+    uniswapV3Router = IUniswapRouter02(router);
+    emit UniswapV3RouterSet(router);
+  }
+
+  function swapExactInputSingle(
+    address tokenIn,
+    address tokenOut,
+    address recipient,
+    uint24 poolFee,
+    uint amountIn
+  ) internal returns (uint amountOut) {
+    if (address(uniswapV3Router) != address(0)) {
+      TransferHelper.safeApprove(tokenIn, address(uniswapV3Router), amountIn);
+
+      IUniswapRouter02.ExactInputSingleParams memory params = IUniswapRouter02
+        .ExactInputSingleParams({
+          tokenIn: tokenIn,
+          tokenOut: tokenOut,
+          fee: poolFee,
+          recipient: recipient,
+          amountIn: amountIn,
+          amountOutMinimum: 0,
+          sqrtPriceLimitX96: 0
+        });
+
+      amountOut = uniswapV3Router.exactInputSingle(params);
+    }
+  }
+
+  
+  event UniswapV3RouterSet(address indexed router);
+
+  
+}
+
+contract BlocjerkTokenV6 is BlocjerkTokenV5, UniswapV3 {
+  
+  function upgradeToV6() external {
+    require(version < 6, "DeHubToken: Already upgraded to version 6");
+    version = 6;
+    console.log("v", version);
+  }
+
+  function _sellTax(
+    uint256 tokenAmount
+  ) internal virtual override lockTheProcess {
+    uint256 tokensSold;
+    uint256 ethReceived;
+
+    if (
+      taxTo != address(0) &&
+      tokenAmount > 0 &&
+      address(uniswapV3Router) != address(0)
+    ) {
+      ethReceived = swapExactInputSingle(
+        address(this),
+        uniswapV3Router.WETH9(),
+        taxTo,
+        3000, 
+        tokenAmount
+      );
+      tokensSold = tokenAmount;
+    }
+    emit SoldTax(tokensSold, ethReceived);
+  }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -48,7 +48,8 @@ const config: HardhatUserConfig = {
   },
   networks: {
     tenderly: {
-      url: `https://rpc.tenderly.co/fork/40a796db-12b7-440f-bb69-0f07a6708a46`,
+      // url: `https://rpc.tenderly.co/fork/40a796db-12b7-440f-bb69-0f07a6708a46`, // mainnet
+      url: `https://rpc.tenderly.co/fork/caa36591-0c9f-414f-b818-585e638ebf63`, // sepolia
       accounts: [process.env.TESTNET_PRIVATE_KEY],
     },
     mainnet: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -47,6 +47,10 @@ const config: HardhatUserConfig = {
     timeout: 50000,
   },
   networks: {
+    tenderly: {
+      url: `https://rpc.tenderly.co/fork/40a796db-12b7-440f-bb69-0f07a6708a46`,
+      accounts: [process.env.TESTNET_PRIVATE_KEY],
+    },
     mainnet: {
       url: `https://eth-mainnet.public.blastapi.io`,
       accounts: [process.env.MAINNET_PRIVATE_KEY],

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -47,10 +47,13 @@ const config: HardhatUserConfig = {
     timeout: 50000,
   },
   networks: {
-    tenderly: {
-      // url: `https://rpc.tenderly.co/fork/40a796db-12b7-440f-bb69-0f07a6708a46`, // mainnet
+    tenderlySepolia: {
       url: `https://rpc.tenderly.co/fork/caa36591-0c9f-414f-b818-585e638ebf63`, // sepolia
       accounts: [process.env.TESTNET_PRIVATE_KEY],
+    },
+    tenderlyMainnet: {
+      url: `https://rpc.tenderly.co/fork/40a796db-12b7-440f-bb69-0f07a6708a46`, // mainnet
+      accounts: [process.env.MAINNET_PRIVATE_KEY],
     },
     mainnet: {
       url: `https://eth-mainnet.public.blastapi.io`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@openzeppelin/hardhat-upgrades": "1.22.0",
         "@uniswap/v2-core": "1.0.1",
         "@uniswap/v2-periphery": "1.1.0-beta.0",
+        "@uniswap/v3-periphery": "1.4.4",
         "dotenv": "16.0.3",
         "ethers": "5.7.2"
       },
@@ -1846,6 +1847,42 @@
         "node": ">=10"
       }
     },
+    "node_modules/@uniswap/v3-core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-core/-/v3-core-1.0.1.tgz",
+      "integrity": "sha512-7pVk4hEm00j9tc71Y9+ssYpO6ytkeI0y7WE9P6UcmNzhxPePwyAxImuhVsTqWK9YFvzgtvzJHi64pBl4jUzKMQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v3-periphery": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-periphery/-/v3-periphery-1.4.4.tgz",
+      "integrity": "sha512-S4+m+wh8HbWSO3DKk4LwUCPZJTpCugIsHrWR86m/OrUyvSqGDTXKFfc2sMuGXCZrD1ZqO3rhQsKgdWg3Hbb2Kw==",
+      "dependencies": {
+        "@openzeppelin/contracts": "3.4.2-solc-0.7",
+        "@uniswap/lib": "^4.0.1-alpha",
+        "@uniswap/v2-core": "^1.0.1",
+        "@uniswap/v3-core": "^1.0.0",
+        "base64-sol": "1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v3-periphery/node_modules/@openzeppelin/contracts": {
+      "version": "3.4.2-solc-0.7",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.2-solc-0.7.tgz",
+      "integrity": "sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA=="
+    },
+    "node_modules/@uniswap/v3-periphery/node_modules/@uniswap/lib": {
+      "version": "4.0.1-alpha",
+      "resolved": "https://registry.npmjs.org/@uniswap/lib/-/lib-4.0.1-alpha.tgz",
+      "integrity": "sha512-f6UIliwBbRsgVLxIaBANF6w09tYqc6Y/qXdsrbEmXHyFA7ILiKrIwRFXe1yOg8M3cksgVsO9N7yuL2DdCGQKBA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -2241,6 +2278,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/base64-sol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/base64-sol/-/base64-sol-1.0.1.tgz",
+      "integrity": "sha512-ld3cCNMeXt4uJXmLZBHFGMvVpK9KsLVEhPpFRXnvSVAqABKbuNZg/+dsq3NuM+wxFLb/UrVkz7m1ciWmkMfTbg=="
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -10460,6 +10502,35 @@
         }
       }
     },
+    "@uniswap/v3-core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-core/-/v3-core-1.0.1.tgz",
+      "integrity": "sha512-7pVk4hEm00j9tc71Y9+ssYpO6ytkeI0y7WE9P6UcmNzhxPePwyAxImuhVsTqWK9YFvzgtvzJHi64pBl4jUzKMQ=="
+    },
+    "@uniswap/v3-periphery": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-periphery/-/v3-periphery-1.4.4.tgz",
+      "integrity": "sha512-S4+m+wh8HbWSO3DKk4LwUCPZJTpCugIsHrWR86m/OrUyvSqGDTXKFfc2sMuGXCZrD1ZqO3rhQsKgdWg3Hbb2Kw==",
+      "requires": {
+        "@openzeppelin/contracts": "3.4.2-solc-0.7",
+        "@uniswap/lib": "^4.0.1-alpha",
+        "@uniswap/v2-core": "^1.0.1",
+        "@uniswap/v3-core": "^1.0.0",
+        "base64-sol": "1.0.1"
+      },
+      "dependencies": {
+        "@openzeppelin/contracts": {
+          "version": "3.4.2-solc-0.7",
+          "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.2-solc-0.7.tgz",
+          "integrity": "sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA=="
+        },
+        "@uniswap/lib": {
+          "version": "4.0.1-alpha",
+          "resolved": "https://registry.npmjs.org/@uniswap/lib/-/lib-4.0.1-alpha.tgz",
+          "integrity": "sha512-f6UIliwBbRsgVLxIaBANF6w09tYqc6Y/qXdsrbEmXHyFA7ILiKrIwRFXe1yOg8M3cksgVsO9N7yuL2DdCGQKBA=="
+        }
+      }
+    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -10753,6 +10824,11 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "base64-sol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/base64-sol/-/base64-sol-1.0.1.tgz",
+      "integrity": "sha512-ld3cCNMeXt4uJXmLZBHFGMvVpK9KsLVEhPpFRXnvSVAqABKbuNZg/+dsq3NuM+wxFLb/UrVkz7m1ciWmkMfTbg=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@openzeppelin/hardhat-upgrades": "1.22.0",
     "@uniswap/v2-core": "1.0.1",
     "@uniswap/v2-periphery": "1.1.0-beta.0",
+    "@uniswap/v3-periphery": "1.4.4",
     "dotenv": "16.0.3",
     "ethers": "5.7.2"
   }

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -10,7 +10,8 @@ export type Network =
   // | "polygonMumbai"
   // | "bsc"
   // | "bscTestnet"
-  | "tenderly";
+  | "tenderlySepolia"
+  | "tenderlyMainnet";
 
 interface Config {
   ownerAddress: string;

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -9,7 +9,8 @@ export type Network =
   // | "polygon"
   // | "polygonMumbai"
   // | "bsc"
-  // | "bscTestnet";
+  // | "bscTestnet"
+  | "tenderly";
 
 interface Config {
   ownerAddress: string;
@@ -99,6 +100,15 @@ export const config: { [network in Network]: Config } = {
     symbol: "BJ",
   },
   arbitrumGoerli: {
+    ownerAddress: "0xD3b5134fef18b69e1ddB986338F2F80CD043a1AF",
+    treasuryAddress: "0xD3b5134fef18b69e1ddB986338F2F80CD043a1AF",
+    totalSupply: ethers.BigNumber.from(oneMillion)
+      .mul(10)
+      .mul(decimals),
+    name: "Blocjerk",
+    symbol: "BJ",
+  },
+  tenderly: {
     ownerAddress: "0xD3b5134fef18b69e1ddB986338F2F80CD043a1AF",
     treasuryAddress: "0xD3b5134fef18b69e1ddB986338F2F80CD043a1AF",
     totalSupply: ethers.BigNumber.from(oneMillion)

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -25,7 +25,8 @@ const main = async () => {
     // network.name === "polygon" ||
     // network.name === "polygonMumbai" ||
     // network.name === "bsc" ||
-    // network.name === "bscTestnet"
+    // network.name === "bscTestnet" ||
+    network.name === "tenderly" ||
     false
   ) {
     console.log(config[network.name]);

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -26,7 +26,8 @@ const main = async () => {
     // network.name === "polygonMumbai" ||
     // network.name === "bsc" ||
     // network.name === "bscTestnet" ||
-    network.name === "tenderly" ||
+    network.name === "tenderlySepolia" ||
+    network.name === "tenderlyMainnet" ||
     false
   ) {
     console.log(config[network.name]);

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -43,16 +43,16 @@ const main = async () => {
     const bjTokenImpl = await upgrades.erc1967.getImplementationAddress(
       bjToken.address
     );
-    // await verifyContract(bjTokenImpl);
+    await verifyContract(bjTokenImpl);
 
-    // console.log(`Minting tokens...`);
-    // const tx = await bjToken.mint(
-    //   config[network.name].treasuryAddress,
-    //   config[network.name].totalSupply
-    // );
-    // console.log(`Waiting to finish...`);
-    // await tx.wait();
-    // console.log(`Finished minting`);
+    console.log(`Minting tokens...`);
+    const tx = await bjToken.mint(
+      config[network.name].treasuryAddress,
+      config[network.name].totalSupply
+    );
+    console.log(`Waiting to finish...`);
+    await tx.wait();
+    console.log(`Finished minting`);
 
     // console.log(
     //   `Transferring token ownership to ${config[network.name].ownerAddress}`

--- a/scripts/fork/config.ts
+++ b/scripts/fork/config.ts
@@ -1,0 +1,58 @@
+import * as hre from "hardhat";
+import { BlocjerkTokenV6__factory, IERC20__factory, IUniswapRouter02__factory, IWETH__factory, TestParent__factory, TestUniswapV3, TestUniswapV3__factory } from "../../typechain";
+import { getManifest } from "../helpers";
+
+const main = async () => {
+  const deployers = await hre.ethers.getSigners();
+  let deployer = deployers[0];
+
+  if (hre.network.name !== "tenderly" && hre.network.name !== "hardhat") {
+    console.log("network", hre.network.name);
+    return;
+  }
+
+  if (hre.network.name === "hardhat") {
+    // Impersonate account
+    await hre.network.provider.request({
+      method: "hardhat_impersonateAccount",
+      params: [deployer.address],
+    });
+
+    await hre.network.provider.send("hardhat_setBalance", [
+      deployer.address,
+      hre.ethers.utils.parseEther("1000").toHexString(),
+    ]);
+  } else if (hre.network.name === "tenderly") {
+    await hre.network.provider.send("tenderly_setBalance", [
+      deployer.address,
+      hre.ethers.utils.parseEther("1000").toHexString(),
+    ]);
+  }
+  
+  console.log("deployer.address", deployer.address);
+
+  const balance = await deployer.getBalance();
+  console.log("Balance", balance.toString());
+
+  const manifest = getManifest(hre.network.name);
+  if (!manifest) {
+    throw new Error(`Not found manifest for ${hre.network.name}`);
+  }
+  const proxyAddr = manifest.proxies[manifest.proxies.length - 1].address;
+  console.log("proxyAddr", proxyAddr);
+
+  const config = {
+    pool: "0xc36442b4a4522e871399cd717abdd847ab11fe88", // BJ+WETH
+    taxTo: deployer.address,
+    minTaxForSell: hre.ethers.utils.parseEther("10"),
+    uniswapV3Router: "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
+  }
+
+  const blocjerkToken = BlocjerkTokenV6__factory.connect(proxyAddr, deployer);
+  await blocjerkToken.addPoolToTax(config.pool);
+  await blocjerkToken.setTaxTo(config.taxTo);
+  await blocjerkToken.setMinTaxForSell(config.minTaxForSell);
+  await blocjerkToken.setUniswapV3Router(config.uniswapV3Router);
+}
+
+main().catch((err) => console.error(err));

--- a/scripts/fork/config.ts
+++ b/scripts/fork/config.ts
@@ -6,7 +6,7 @@ const main = async () => {
   const deployers = await hre.ethers.getSigners();
   let deployer = deployers[0];
 
-  if (hre.network.name !== "tenderly" && hre.network.name !== "hardhat") {
+  if (hre.network.name !== "tenderlySepolia" && hre.network.name !== "tenderlyMainnet" && hre.network.name !== "hardhat") {
     console.log("network", hre.network.name);
     return;
   }
@@ -22,7 +22,7 @@ const main = async () => {
       deployer.address,
       hre.ethers.utils.parseEther("1000").toHexString(),
     ]);
-  } else if (hre.network.name === "tenderly") {
+  } else if (hre.network.name === "tenderlySepolia" || hre.network.name === "tenderlyMainnet") {
     await hre.network.provider.send("tenderly_setBalance", [
       deployer.address,
       hre.ethers.utils.parseEther("1000").toHexString(),

--- a/scripts/fork/swap.ts
+++ b/scripts/fork/swap.ts
@@ -39,8 +39,8 @@ const main = async () => {
   console.log("TestUniswapV3", testUniswapV3.address);
   console.log("owner", await testUniswapV3.owner());
 
-  await testUniswapV3.setUniswapV3Router("0xE592427A0AEce92De3Edee1F18E0157C05861564");
-  console.log("set router: 0xE592427A0AEce92De3Edee1F18E0157C05861564");
+  await testUniswapV3.setUniswapV3Router("0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45");
+  console.log("set router: 0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45");
 
   const amount = hre.ethers.utils.parseEther("100");
   console.log("amount", amount.toString());

--- a/scripts/fork/swap.ts
+++ b/scripts/fork/swap.ts
@@ -1,0 +1,65 @@
+import * as hre from "hardhat";
+import { IERC20__factory, IWETH__factory, TestParent__factory, TestUniswapV3, TestUniswapV3__factory } from "../../typechain";
+
+const main = async () => {
+  const deployers = await hre.ethers.getSigners();
+  let deployer = deployers[0];
+
+  if (hre.network.name !== "tenderly" && hre.network.name !== "hardhat") {
+    console.log("network", hre.network.name);
+    return;
+  }
+
+  if (hre.network.name === "hardhat") {
+    // Impersonate account
+    await hre.network.provider.request({
+      method: "hardhat_impersonateAccount",
+      params: [deployer.address],
+    });
+
+    await hre.network.provider.send("hardhat_setBalance", [
+      deployer.address,
+      hre.ethers.utils.parseEther("1000").toHexString(),
+    ]);
+  } else if (hre.network.name === "tenderly") {
+    await hre.network.provider.send("tenderly_setBalance", [
+      deployer.address,
+      hre.ethers.utils.parseEther("1000").toHexString(),
+    ]);
+  }
+  
+  console.log("deployer.address", deployer.address);
+
+  const balance = await deployer.getBalance();
+  console.log("Balance", balance.toString());
+  
+  const TestUniswapV3Factory = new TestUniswapV3__factory(deployer);
+  const testUniswapV3 = await TestUniswapV3Factory.deploy();
+  await testUniswapV3.deployTransaction.wait();
+  console.log("TestUniswapV3", testUniswapV3.address);
+  console.log("owner", await testUniswapV3.owner());
+
+  await testUniswapV3.setUniswapV3Router("0xE592427A0AEce92De3Edee1F18E0157C05861564");
+  console.log("set router: 0xE592427A0AEce92De3Edee1F18E0157C05861564");
+
+  const amount = hre.ethers.utils.parseEther("100");
+  console.log("amount", amount.toString());
+  const WETH = IWETH__factory.connect("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", deployer);
+  await WETH.deposit({ value: amount });
+  console.log("WETH balance", (await WETH.balanceOf(deployer.address)).toString());
+  
+  await WETH.approve(testUniswapV3.address, amount);
+  console.log("approve testUniswapV3");
+  await testUniswapV3.swapExactInputSingle(
+    "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // WETH
+    "0x6B175474E89094C44Da98b954EedeAC495271d0F", // DAI
+    "0x1036c5BE9cD90febbeE0DB547c83D3baB70795f8", // recipient
+    3000,
+    amount
+  );
+  console.log("swap weth for dai");
+
+  //{"tokenIn":"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2","tokenOut":"0x6B175474E89094C44Da98b954EedeAC495271d0F","fee":3000,"recipient":"0xD3b5134fef18b69e1ddB986338F2F80CD043a1AF","deadline":1811830805,"amountIn":"1000000000000000000","amountOutMinimum":0,"sqrtPriceLimitX96":0}
+}
+
+main().catch((err) => console.error(err));

--- a/scripts/fork/swap.ts
+++ b/scripts/fork/swap.ts
@@ -5,7 +5,7 @@ const main = async () => {
   const deployers = await hre.ethers.getSigners();
   let deployer = deployers[0];
 
-  if (hre.network.name !== "tenderly" && hre.network.name !== "hardhat") {
+  if (hre.network.name !== "tenderlySepolia" && hre.network.name !== "tenderlyMainnet" && hre.network.name !== "hardhat") {
     console.log("network", hre.network.name);
     return;
   }
@@ -21,7 +21,7 @@ const main = async () => {
       deployer.address,
       hre.ethers.utils.parseEther("1000").toHexString(),
     ]);
-  } else if (hre.network.name === "tenderly") {
+  } else if (hre.network.name === "tenderlySepolia" || hre.network.name === "tenderlyMainnet") {
     await hre.network.provider.send("tenderly_setBalance", [
       deployer.address,
       hre.ethers.utils.parseEther("1000").toHexString(),

--- a/scripts/fork/swap.ts
+++ b/scripts/fork/swap.ts
@@ -1,5 +1,5 @@
 import * as hre from "hardhat";
-import { IERC20__factory, IWETH__factory, TestParent__factory, TestUniswapV3, TestUniswapV3__factory } from "../../typechain";
+import { IERC20__factory, IUniswapRouter02__factory, IWETH__factory, TestParent__factory, TestUniswapV3, TestUniswapV3__factory } from "../../typechain";
 
 const main = async () => {
   const deployers = await hre.ethers.getSigners();
@@ -39,12 +39,17 @@ const main = async () => {
   console.log("TestUniswapV3", testUniswapV3.address);
   console.log("owner", await testUniswapV3.owner());
 
-  await testUniswapV3.setUniswapV3Router("0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45");
-  console.log("set router: 0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45");
+  const routerAddress = "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45";
+  await testUniswapV3.setUniswapV3Router(routerAddress);
+  console.log(`set router: ${routerAddress}`);
+
+  const router = IUniswapRouter02__factory.connect(routerAddress, deployer);
+  const wETHAddress = await router.WETH9();
+  console.log(`wETH: ${wETHAddress}`);
 
   const amount = hre.ethers.utils.parseEther("100");
   console.log("amount", amount.toString());
-  const WETH = IWETH__factory.connect("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", deployer);
+  const WETH = IWETH__factory.connect(wETHAddress, deployer);
   await WETH.deposit({ value: amount });
   console.log("WETH balance", (await WETH.balanceOf(deployer.address)).toString());
   

--- a/scripts/helpers.ts
+++ b/scripts/helpers.ts
@@ -44,10 +44,10 @@ export const calculateGasMargin = (
 };
 
 export const getManifest = (network: string) => {
-  if (network === "mainnet" || network === "tenderly") {
+  if (network === "mainnet" || network === "tenderlyMainnet") {
     return manifestMainnet;
   }
-  if (network === "sepolia") {
+  if (network === "sepolia" || network === "tenderlySepolia") {
     return manifestSepolia;
   }
   if (network === "arbitrumOne") {

--- a/scripts/helpers.ts
+++ b/scripts/helpers.ts
@@ -44,7 +44,7 @@ export const calculateGasMargin = (
 };
 
 export const getManifest = (network: string) => {
-  if (network === "mainnet") {
+  if (network === "mainnet" || network === "tenderly") {
     return manifestMainnet;
   }
   if (network === "sepolia") {

--- a/scripts/upgrade.ts
+++ b/scripts/upgrade.ts
@@ -34,7 +34,7 @@ const main = async () => {
 
   console.log(`BlocjerkToken upgraded at ${bjToken.address}`);
 
-  console.log("Sleeping for 5 seconds for deployment...");
+  console.log("Sleeping for 10 seconds for deployment...");
   await sleep(10000);
 
   const blocjerkTokenImpl = await upgrades.erc1967.getImplementationAddress(

--- a/scripts/upgrade.ts
+++ b/scripts/upgrade.ts
@@ -1,11 +1,11 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { ethers, network, upgrades } from "hardhat";
 import {
-  BlocjerkTokenV5,
-  BlocjerkTokenV4__factory,
+  BlocjerkTokenV6,
   BlocjerkTokenV5__factory,
+  BlocjerkTokenV6__factory,
 } from "../typechain";
-import { getManifest, verifyContract } from "./helpers";
+import { getManifest, sleep, verifyContract } from "./helpers";
 
 const main = async () => {
   const signers = await ethers.getSigners();
@@ -25,14 +25,17 @@ const main = async () => {
 
   console.log("Proxy Address", proxyAddr);
 
-  // const BlocjerkTokenV4Factory = new BlocjerkTokenV4__factory(deployer);
-  // await upgrades.forceImport(proxyAddr, BlocjerkTokenV4Factory);
-  const BlocjerkTokenV5Factory = new BlocjerkTokenV5__factory(deployer);
+  // const BlocjerkTokenV5Factory = new BlocjerkTokenV5__factory(deployer);
+  // await upgrades.forceImport(proxyAddr, BlocjerkTokenV5Factory);
+  const BlocjerkTokenV6Factory = new BlocjerkTokenV6__factory(deployer);
   const bjToken = (await upgrades.upgradeProxy(
     proxyAddr,
-    BlocjerkTokenV5Factory)) as BlocjerkTokenV5;
+    BlocjerkTokenV6Factory)) as BlocjerkTokenV6;
 
   console.log(`BlocjerkToken upgraded at ${bjToken.address}`);
+
+  console.log("Sleeping for 5 seconds for deployment...");
+  await sleep(10000);
 
   const blocjerkTokenImpl = await upgrades.erc1967.getImplementationAddress(
     bjToken.address

--- a/scripts/upgrade.ts
+++ b/scripts/upgrade.ts
@@ -21,6 +21,15 @@ const main = async () => {
     throw new Error(`Not found manifest for ${network.name}`);
   }
 
+  if (network.name === "tenderlySepolia" || network.name === "tenderlyMainnet") {
+    await network.provider.send("tenderly_setBalance", [
+      deployer.address,
+      ethers.utils.parseEther("1000").toHexString(),
+    ]);
+    const balance = await deployer.getBalance();
+    console.log("Balance", balance.toString());
+  }
+
   const proxyAddr = manifest.proxies[0].address;
 
   console.log("Proxy Address", proxyAddr);

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -1,11 +1,10 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { ethers, network, upgrades } from "hardhat";
 import {
-  BlocjerkTokenV4__factory,
   BlocjerkTokenV5__factory,
+  BlocjerkTokenV6__factory,
 } from "../typechain";
-import { config } from "./config";
-import { getManifest, verifyContract } from "./helpers";
+import { getManifest } from "./helpers";
 
 const main = async () => {
   const signers = await ethers.getSigners();
@@ -25,13 +24,13 @@ const main = async () => {
 
   console.log("Proxy Address", proxyAddr);
 
-  const BlocjerkTokenV4Factory = new BlocjerkTokenV4__factory(deployer);
   const BlocjerkTokenV5Factory = new BlocjerkTokenV5__factory(deployer);
+  const BlocjerkTokenV6Factory = new BlocjerkTokenV6__factory(deployer);
 
   // Validate the upgrade without deploying/upgrading it
-  await upgrades.validateUpgrade(BlocjerkTokenV4Factory, BlocjerkTokenV5Factory);
+  await upgrades.validateUpgrade(BlocjerkTokenV5Factory, BlocjerkTokenV6Factory);
 
-  await upgrades.validateImplementation(BlocjerkTokenV5Factory);
+  await upgrades.validateImplementation(BlocjerkTokenV6Factory);
 };
 
 // We recommend this pattern to be able to use async/await everywhere

--- a/test/UpgradabilityV6.ts
+++ b/test/UpgradabilityV6.ts
@@ -1,0 +1,74 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { BlocjerkTokenV4UpgradeSafeWithCore__factory, TestParent__factory, BlocjerkTokenV5__factory, BlocjerkTokenV5, BlocjerkTokenV6__factory } from "../typechain";
+import { ethers, upgrades } from "hardhat";
+import { expect } from "chai";
+
+describe("UpgradeabilityV6", () => {
+  let deployer: SignerWithAddress,
+    pool: SignerWithAddress,
+    taxTo: SignerWithAddress,
+    user1: SignerWithAddress,
+    user2: SignerWithAddress;
+
+  let blocjerkToken: BlocjerkTokenV5;
+
+  beforeEach("initial setup", async () => {
+    [deployer, pool, taxTo, user1, user2] = await ethers.getSigners();
+
+    const blocjerkTokenFactory = new BlocjerkTokenV5__factory(deployer);
+    blocjerkToken = (await upgrades.deployProxy(blocjerkTokenFactory, [
+      "Blocjerk",
+      "DHB",
+    ])) as BlocjerkTokenV5;
+    await blocjerkToken.deployed();
+
+    await blocjerkToken.setTaxTo(taxTo.address);
+
+    await blocjerkToken.mint(pool.address, ethers.utils.parseEther("30000"));
+    await blocjerkToken.mint(user1.address, ethers.utils.parseEther("20000"));
+    await blocjerkToken.mint(user2.address, ethers.utils.parseEther("10000"));
+
+    // set some storage
+    await blocjerkToken.setBuySellTaxRate(100, 200);
+    await blocjerkToken.authorizeSnapshotter(user1.address);
+    await blocjerkToken.authorizeSnapshotter(user2.address);
+    await blocjerkToken.addPoolToTax(user1.address);
+    await blocjerkToken.addPoolToTax(user2.address);
+  });
+
+  it("upgrade safe test with v6", async () => {
+    // Backup storage values before upgrade
+    const poolBalance = await blocjerkToken.balanceOf(pool.address);
+    const user1Balance = await blocjerkToken.balanceOf(user1.address);
+    const user2Balance = await blocjerkToken.balanceOf(user2.address);
+
+    const buySellTaxRate = await blocjerkToken.buyTaxRate();
+    const poolUser1 = await blocjerkToken.poolsToTax(user1.address);
+    const poolUser2 = await blocjerkToken.poolsToTax(user2.address);
+
+    try {
+      const BlocjerkTokenV5Factory = new BlocjerkTokenV6__factory(deployer);
+      await upgrades.upgradeProxy(blocjerkToken, BlocjerkTokenV5Factory);
+    } catch (err) {
+      console.error(err);
+      expect(false).to.be.true;
+      return;
+    }
+
+    // Get storage values again after upgrade
+    const poolBalanceAfter = await blocjerkToken.balanceOf(pool.address);
+    const user1BalanceAfter = await blocjerkToken.balanceOf(user1.address);
+    const user2BalanceAfter = await blocjerkToken.balanceOf(user2.address);
+
+    const buySellTaxRateAfter = await blocjerkToken.buyTaxRate();
+    const poolUser1After = await blocjerkToken.poolsToTax(user1.address);
+    const poolUser2After = await blocjerkToken.poolsToTax(user2.address);
+
+    expect(poolBalance).eq(poolBalanceAfter);
+    expect(user1Balance).eq(user1BalanceAfter);
+    expect(user2Balance).eq(user2BalanceAfter);
+    expect(buySellTaxRate).eq(buySellTaxRateAfter);
+    expect(poolUser1).eq(poolUser1After);
+    expect(poolUser2).eq(poolUser2After);
+  });
+});


### PR DESCRIPTION
# Key Updates from BlocjerkTokenV6

- Ability to sell accumulated tax fee for WETH through Uniswap V3 Router and send WTH to taxTo wallet address when regular transfer.
- Swap tax fee through Uniswap V2 Router while adding liquidity on Camelot V2.